### PR TITLE
M2 #21: Remove deribit-base dependency and inline setup_logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - GitHub Actions CI/CD pipeline (build, lint, test, coverage, semver)
 - Dependabot configuration for automated dependency updates
+- Local `utils` module with `setup_logger()` function
+
+### Removed
+- **BREAKING**: Removed `deribit-base` dependency - crate is now fully self-contained
+- Removed `pub use deribit_base;` re-export from `lib.rs`
+- Removed `pub use deribit_base::prelude::*;` from `prelude.rs`
+
+### Changed
+- Added `tracing-subscriber` dependency for logger functionality
 
 ## [0.1.2] - 2024-03-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ integration-tests = []
 
 
 [dependencies]
-deribit-base = { workspace = true }
 pretty-simple-display = { workspace = true }
+tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
@@ -36,8 +36,8 @@ serial_test = "3.4"
 dotenv = "0.15"
 
 [workspace.dependencies]
-deribit-base = "0.2.6"
 pretty-simple-display = "0.1"
+tracing-subscriber = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,5 @@ pub mod model;
 pub mod prelude;
 pub mod session;
 pub mod subscriptions;
-
-// Re-export common types from deribit-base
-pub use deribit_base;
+/// Utility functions and helpers
+pub mod utils;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -40,8 +40,8 @@ pub use crate::subscriptions::SubscriptionChannel;
 // Constants
 pub use crate::constants::*;
 
-// Re-export commonly used types from deribit-base
-pub use deribit_base::prelude::*;
+// Utility functions
+pub use crate::utils::setup_logger;
 
 // Re-export commonly used external types
 pub use serde_json::{Value, json};

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -1,0 +1,69 @@
+//! Logger setup utility for the deribit-websocket crate
+//!
+//! Provides a simple logger configuration based on environment variables.
+
+use std::env;
+use std::sync::Once;
+use tracing::Level;
+use tracing_subscriber::FmtSubscriber;
+
+static INIT: Once = Once::new();
+
+/// Sets up the logger for the application.
+///
+/// The logger level is determined by the `DERIBIT_LOG_LEVEL` environment variable.
+/// If the variable is not set, it defaults to `INFO`.
+///
+/// This function is safe to call multiple times - it will only initialize
+/// the logger once.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use deribit_websocket::utils::setup_logger;
+///
+/// // Set log level via environment variable (unsafe in Rust 2024 edition)
+/// unsafe {
+///     std::env::set_var("DERIBIT_LOG_LEVEL", "DEBUG");
+/// }
+///
+/// // Initialize the logger
+/// setup_logger();
+///
+/// // Now you can use tracing macros
+/// tracing::info!("Logger initialized");
+/// ```
+pub fn setup_logger() {
+    INIT.call_once(|| {
+        let log_level = env::var("DERIBIT_LOG_LEVEL")
+            .unwrap_or_else(|_| "INFO".to_string())
+            .to_uppercase();
+
+        let level = match log_level.as_str() {
+            "DEBUG" => Level::DEBUG,
+            "ERROR" => Level::ERROR,
+            "WARN" => Level::WARN,
+            "TRACE" => Level::TRACE,
+            _ => Level::INFO,
+        };
+
+        let subscriber = FmtSubscriber::builder().with_max_level(level).finish();
+
+        if tracing::subscriber::set_global_default(subscriber).is_ok() {
+            tracing::debug!("Log level set to: {}", level);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_setup_logger_can_be_called_multiple_times() {
+        // First call
+        setup_logger();
+        // Second call should not panic
+        setup_logger();
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,7 @@
+//! Utility functions and helpers for the deribit-websocket crate
+//!
+//! This module provides common utilities used throughout the crate.
+
+mod logger;
+
+pub use logger::setup_logger;

--- a/tests/integration/authentication/oauth_flow.rs
+++ b/tests/integration/authentication/oauth_flow.rs
@@ -10,7 +10,6 @@
 use std::path::Path;
 use tracing::{debug, error, info, warn};
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables

--- a/tests/integration/connection/basic_connection.rs
+++ b/tests/integration/connection/basic_connection.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, info};
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables

--- a/tests/integration/connection/connection_recovery.rs
+++ b/tests/integration/connection/connection_recovery.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, info};
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables

--- a/tests/integration/connection/ssl_connection.rs
+++ b/tests/integration/connection/ssl_connection.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tracing::{debug, error, info};
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables

--- a/tests/integration/error_handling/connection_errors.rs
+++ b/tests/integration/error_handling/connection_errors.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 use tokio::time::{sleep, timeout};
 use tracing::info;
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables

--- a/tests/integration/market_data/ticker_data.rs
+++ b/tests/integration/market_data/ticker_data.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, info};
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables

--- a/tests/integration/subscriptions/basic_subscriptions.rs
+++ b/tests/integration/subscriptions/basic_subscriptions.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info};
 
-use deribit_base::prelude::*;
 use deribit_websocket::prelude::*;
 
 /// Check if .env file exists and contains required variables


### PR DESCRIPTION
## Summary

Remove `deribit-base` crate dependency and make deribit-websocket fully self-contained by inlining only the utilities actually used.

## Changes

### Added
- `src/utils/mod.rs` - new utils module
- `src/utils/logger.rs` - local `setup_logger()` function

### Modified
- `Cargo.toml` - removed `deribit-base`, added `tracing-subscriber`
- `src/lib.rs` - removed `pub use deribit_base;`, added `pub mod utils;`
- `src/prelude.rs` - replaced `deribit_base::prelude::*` with `crate::utils::setup_logger`
- 7 integration test files - updated imports

## Breaking Change

Users who relied on `deribit_base` types re-exported via this crate will need to add `deribit-base` as their own dependency. This is intentional for proper separation of concerns.

## Testing

- [x] 94 tests pass (10 lib + 79 unit + 5 doc tests)
- [x] `make lint-fix` passes
- [x] `make pre-push` passes

## Checklist

- [x] `deribit-base` removed from Cargo.toml
- [x] `setup_logger()` available via `prelude::*`
- [x] All tests pass
- [x] Documentation updated
- [x] CHANGELOG updated

Closes #21
