### PR TITLE
M2 #5: Implement trading methods over WebSocket (buy, sell, cancel, edit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI/CD pipeline (build, lint, test, coverage, semver)
 - Dependabot configuration for automated dependency updates
 - Local `utils` module with `setup_logger()` function
+- Trading methods over WebSocket: `buy()`, `sell()`, `cancel()`, `cancel_all()`, `cancel_all_by_currency()`, `cancel_all_by_instrument()`, `edit()`
+- New trading types: `OrderRequest`, `EditOrderRequest`, `OrderResponse`, `OrderInfo`, `OrderType`, `TimeInForce`, `Trigger`, `TradeExecution`
+- Request builders for all trading operations
+- Comprehensive unit tests for trading module (36 tests)
 
 ### Removed
 - **BREAKING**: Removed `deribit-base` dependency - crate is now fully self-contained

--- a/src/client.rs
+++ b/src/client.rs
@@ -372,6 +372,215 @@ impl DeribitWebSocketClient {
         }
     }
 
+    /// Place a buy order
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The order request parameters
+    ///
+    /// # Returns
+    ///
+    /// Returns `OrderResponse` containing order info and any immediate trades
+    pub async fn buy(
+        &self,
+        request: crate::model::trading::OrderRequest,
+    ) -> Result<crate::model::trading::OrderResponse, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_buy_request(&request)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!("Failed to parse buy response: {}", e))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Place a sell order
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The order request parameters
+    ///
+    /// # Returns
+    ///
+    /// Returns `OrderResponse` containing order info and any immediate trades
+    pub async fn sell(
+        &self,
+        request: crate::model::trading::OrderRequest,
+    ) -> Result<crate::model::trading::OrderResponse, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_sell_request(&request)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!("Failed to parse sell response: {}", e))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Cancel an order by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - The order ID to cancel
+    ///
+    /// # Returns
+    ///
+    /// Returns `OrderInfo` for the cancelled order
+    pub async fn cancel(
+        &self,
+        order_id: &str,
+    ) -> Result<crate::model::trading::OrderInfo, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_cancel_request(order_id)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!("Failed to parse cancel response: {}", e))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Cancel all orders
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of orders cancelled
+    pub async fn cancel_all(&self) -> Result<u32, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_cancel_all_request()
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!(
+                    "Failed to parse cancel_all response: {}",
+                    e
+                ))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Cancel all orders by currency
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency to cancel orders for (e.g., "BTC", "ETH")
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of orders cancelled
+    pub async fn cancel_all_by_currency(&self, currency: &str) -> Result<u32, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_cancel_all_by_currency_request(currency)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!(
+                    "Failed to parse cancel_all_by_currency response: {}",
+                    e
+                ))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Cancel all orders by instrument
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - Instrument name to cancel orders for (e.g., "BTC-PERPETUAL")
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of orders cancelled
+    pub async fn cancel_all_by_instrument(
+        &self,
+        instrument_name: &str,
+    ) -> Result<u32, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_cancel_all_by_instrument_request(instrument_name)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!(
+                    "Failed to parse cancel_all_by_instrument response: {}",
+                    e
+                ))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Edit an existing order
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The edit order request parameters
+    ///
+    /// # Returns
+    ///
+    /// Returns `OrderResponse` containing updated order info and any trades
+    pub async fn edit(
+        &self,
+        request: crate::model::trading::EditOrderRequest,
+    ) -> Result<crate::model::trading::OrderResponse, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_edit_request(&request)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!("Failed to parse edit response: {}", e))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
     /// Set message handler with callbacks
     /// The message_callback processes each incoming message and returns Result<(), Error>
     /// The error_callback is called only when message_callback returns an error

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,6 +48,12 @@ pub mod methods {
     pub const PRIVATE_CANCEL: &str = "private/cancel";
     /// Cancel all orders
     pub const PRIVATE_CANCEL_ALL: &str = "private/cancel_all";
+    /// Cancel all orders by currency
+    pub const PRIVATE_CANCEL_ALL_BY_CURRENCY: &str = "private/cancel_all_by_currency";
+    /// Cancel all orders by instrument
+    pub const PRIVATE_CANCEL_ALL_BY_INSTRUMENT: &str = "private/cancel_all_by_instrument";
+    /// Edit an existing order
+    pub const PRIVATE_EDIT: &str = "private/edit";
     /// Get open orders
     pub const PRIVATE_GET_OPEN_ORDERS: &str = "private/get_open_orders";
 

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -1,6 +1,6 @@
 //! WebSocket request message handling
 
-use crate::model::{quote::*, ws_types::JsonRpcRequest};
+use crate::model::{quote::*, trading::*, ws_types::JsonRpcRequest};
 
 /// Request builder for WebSocket messages
 #[derive(Debug, Clone)]
@@ -155,5 +155,195 @@ impl RequestBuilder {
         }
 
         self.build_request("private/get_open_orders", Some(params))
+    }
+
+    /// Build buy order request
+    pub fn build_buy_request(&mut self, request: &OrderRequest) -> JsonRpcRequest {
+        let mut params = serde_json::json!({
+            "instrument_name": request.instrument_name,
+            "amount": request.amount
+        });
+
+        if let Some(ref order_type) = request.order_type {
+            params["type"] = serde_json::Value::String(order_type.as_str().to_string());
+        }
+        if let Some(price) = request.price {
+            params["price"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(price).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(ref label) = request.label {
+            params["label"] = serde_json::Value::String(label.clone());
+        }
+        if let Some(ref tif) = request.time_in_force {
+            params["time_in_force"] = serde_json::Value::String(tif.as_str().to_string());
+        }
+        if let Some(max_show) = request.max_show {
+            params["max_show"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(max_show).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(post_only) = request.post_only {
+            params["post_only"] = serde_json::Value::Bool(post_only);
+        }
+        if let Some(reduce_only) = request.reduce_only {
+            params["reduce_only"] = serde_json::Value::Bool(reduce_only);
+        }
+        if let Some(trigger_price) = request.trigger_price {
+            params["trigger_price"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(trigger_price).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(ref trigger) = request.trigger {
+            let trigger_str = match trigger {
+                Trigger::IndexPrice => "index_price",
+                Trigger::MarkPrice => "mark_price",
+                Trigger::LastPrice => "last_price",
+            };
+            params["trigger"] = serde_json::Value::String(trigger_str.to_string());
+        }
+        if let Some(ref advanced) = request.advanced {
+            params["advanced"] = serde_json::Value::String(advanced.clone());
+        }
+        if let Some(mmp) = request.mmp {
+            params["mmp"] = serde_json::Value::Bool(mmp);
+        }
+        if let Some(valid_until) = request.valid_until {
+            params["valid_until"] =
+                serde_json::Value::Number(serde_json::Number::from(valid_until));
+        }
+
+        self.build_request("private/buy", Some(params))
+    }
+
+    /// Build sell order request
+    pub fn build_sell_request(&mut self, request: &OrderRequest) -> JsonRpcRequest {
+        let mut params = serde_json::json!({
+            "instrument_name": request.instrument_name,
+            "amount": request.amount
+        });
+
+        if let Some(ref order_type) = request.order_type {
+            params["type"] = serde_json::Value::String(order_type.as_str().to_string());
+        }
+        if let Some(price) = request.price {
+            params["price"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(price).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(ref label) = request.label {
+            params["label"] = serde_json::Value::String(label.clone());
+        }
+        if let Some(ref tif) = request.time_in_force {
+            params["time_in_force"] = serde_json::Value::String(tif.as_str().to_string());
+        }
+        if let Some(max_show) = request.max_show {
+            params["max_show"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(max_show).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(post_only) = request.post_only {
+            params["post_only"] = serde_json::Value::Bool(post_only);
+        }
+        if let Some(reduce_only) = request.reduce_only {
+            params["reduce_only"] = serde_json::Value::Bool(reduce_only);
+        }
+        if let Some(trigger_price) = request.trigger_price {
+            params["trigger_price"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(trigger_price).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(ref trigger) = request.trigger {
+            let trigger_str = match trigger {
+                Trigger::IndexPrice => "index_price",
+                Trigger::MarkPrice => "mark_price",
+                Trigger::LastPrice => "last_price",
+            };
+            params["trigger"] = serde_json::Value::String(trigger_str.to_string());
+        }
+        if let Some(ref advanced) = request.advanced {
+            params["advanced"] = serde_json::Value::String(advanced.clone());
+        }
+        if let Some(mmp) = request.mmp {
+            params["mmp"] = serde_json::Value::Bool(mmp);
+        }
+        if let Some(valid_until) = request.valid_until {
+            params["valid_until"] =
+                serde_json::Value::Number(serde_json::Number::from(valid_until));
+        }
+
+        self.build_request("private/sell", Some(params))
+    }
+
+    /// Build cancel order request
+    pub fn build_cancel_request(&mut self, order_id: &str) -> JsonRpcRequest {
+        let params = serde_json::json!({
+            "order_id": order_id
+        });
+
+        self.build_request("private/cancel", Some(params))
+    }
+
+    /// Build cancel all orders request
+    pub fn build_cancel_all_request(&mut self) -> JsonRpcRequest {
+        self.build_request("private/cancel_all", Some(serde_json::json!({})))
+    }
+
+    /// Build cancel all orders by currency request
+    pub fn build_cancel_all_by_currency_request(&mut self, currency: &str) -> JsonRpcRequest {
+        let params = serde_json::json!({
+            "currency": currency
+        });
+
+        self.build_request("private/cancel_all_by_currency", Some(params))
+    }
+
+    /// Build cancel all orders by instrument request
+    pub fn build_cancel_all_by_instrument_request(
+        &mut self,
+        instrument_name: &str,
+    ) -> JsonRpcRequest {
+        let params = serde_json::json!({
+            "instrument_name": instrument_name
+        });
+
+        self.build_request("private/cancel_all_by_instrument", Some(params))
+    }
+
+    /// Build edit order request
+    pub fn build_edit_request(&mut self, request: &EditOrderRequest) -> JsonRpcRequest {
+        let mut params = serde_json::json!({
+            "order_id": request.order_id,
+            "amount": request.amount
+        });
+
+        if let Some(price) = request.price {
+            params["price"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(price).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(post_only) = request.post_only {
+            params["post_only"] = serde_json::Value::Bool(post_only);
+        }
+        if let Some(reduce_only) = request.reduce_only {
+            params["reduce_only"] = serde_json::Value::Bool(reduce_only);
+        }
+        if let Some(ref advanced) = request.advanced {
+            params["advanced"] = serde_json::Value::String(advanced.clone());
+        }
+        if let Some(trigger_price) = request.trigger_price {
+            params["trigger_price"] = serde_json::Value::Number(
+                serde_json::Number::from_f64(trigger_price).unwrap_or(serde_json::Number::from(0)),
+            );
+        }
+        if let Some(mmp) = request.mmp {
+            params["mmp"] = serde_json::Value::Bool(mmp);
+        }
+        if let Some(valid_until) = request.valid_until {
+            params["valid_until"] =
+                serde_json::Value::Number(serde_json::Number::from(valid_until));
+        }
+
+        self.build_request("private/edit", Some(params))
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod quote;
 pub mod subscription;
+pub mod trading;
 pub mod ws_types;
 
 pub use quote::*;
 pub use subscription::*;
+pub use trading::*;
 pub use ws_types::*;

--- a/src/model/trading.rs
+++ b/src/model/trading.rs
@@ -1,0 +1,504 @@
+//! Trading model definitions for Deribit WebSocket API
+//!
+//! This module provides types for buy, sell, cancel, and edit order operations.
+
+use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
+
+/// Order type enumeration
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderType {
+    /// Limit order - executes at specified price or better
+    Limit,
+    /// Market order - executes immediately at best available price
+    Market,
+    /// Stop limit order - becomes limit order when stop price is reached
+    StopLimit,
+    /// Stop market order - becomes market order when stop price is reached
+    StopMarket,
+    /// Take limit order - limit order to take profit
+    TakeLimit,
+    /// Take market order - market order to take profit
+    TakeMarket,
+    /// Market limit order - market order with limit price protection
+    MarketLimit,
+    /// Trailing stop order - stop order that trails the market price
+    TrailingStop,
+}
+
+impl OrderType {
+    /// Returns the string representation of the order type
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OrderType::Limit => "limit",
+            OrderType::Market => "market",
+            OrderType::StopLimit => "stop_limit",
+            OrderType::StopMarket => "stop_market",
+            OrderType::TakeLimit => "take_limit",
+            OrderType::TakeMarket => "take_market",
+            OrderType::MarketLimit => "market_limit",
+            OrderType::TrailingStop => "trailing_stop",
+        }
+    }
+}
+
+/// Time in force specification for orders
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeInForce {
+    /// Good till cancelled - order remains active until filled or cancelled
+    #[serde(rename = "good_til_cancelled")]
+    GoodTilCancelled,
+    /// Good till day - order expires at end of trading day
+    #[serde(rename = "good_til_day")]
+    GoodTilDay,
+    /// Fill or kill - order must be filled immediately and completely or cancelled
+    #[serde(rename = "fill_or_kill")]
+    FillOrKill,
+    /// Immediate or cancel - fill what can be filled immediately, cancel the rest
+    #[serde(rename = "immediate_or_cancel")]
+    ImmediateOrCancel,
+}
+
+impl TimeInForce {
+    /// Returns the string representation of the time in force
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TimeInForce::GoodTilCancelled => "good_til_cancelled",
+            TimeInForce::GoodTilDay => "good_til_day",
+            TimeInForce::FillOrKill => "fill_or_kill",
+            TimeInForce::ImmediateOrCancel => "immediate_or_cancel",
+        }
+    }
+}
+
+/// Trigger type for conditional orders
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+#[serde(rename_all = "snake_case")]
+pub enum Trigger {
+    /// Trigger based on index price
+    IndexPrice,
+    /// Trigger based on mark price
+    MarkPrice,
+    /// Trigger based on last traded price
+    LastPrice,
+}
+
+/// Order request parameters for buy/sell operations
+#[derive(Clone, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+pub struct OrderRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL")
+    pub instrument_name: String,
+    /// Order amount (positive number)
+    pub amount: f64,
+    /// Order type (limit, market, etc.)
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub order_type: Option<OrderType>,
+    /// User-defined label for the order (max 64 chars)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Limit price for the order
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    /// Time in force specification
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in_force: Option<TimeInForce>,
+    /// Maximum amount to show in order book (for iceberg orders)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_show: Option<f64>,
+    /// Whether the order should only be posted (not taken)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_only: Option<bool>,
+    /// Whether this order only reduces position
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_only: Option<bool>,
+    /// Trigger price for conditional orders
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+    /// Trigger type for conditional orders
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<Trigger>,
+    /// Advanced order type (usd or implv)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub advanced: Option<String>,
+    /// Market maker protection flag
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mmp: Option<bool>,
+    /// Order validity timestamp (Unix timestamp in milliseconds)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<u64>,
+}
+
+impl OrderRequest {
+    /// Create a new limit order request
+    #[must_use]
+    pub fn limit(instrument_name: String, amount: f64, price: f64) -> Self {
+        Self {
+            instrument_name,
+            amount,
+            order_type: Some(OrderType::Limit),
+            label: None,
+            price: Some(price),
+            time_in_force: None,
+            max_show: None,
+            post_only: None,
+            reduce_only: None,
+            trigger_price: None,
+            trigger: None,
+            advanced: None,
+            mmp: None,
+            valid_until: None,
+        }
+    }
+
+    /// Create a new market order request
+    #[must_use]
+    pub fn market(instrument_name: String, amount: f64) -> Self {
+        Self {
+            instrument_name,
+            amount,
+            order_type: Some(OrderType::Market),
+            label: None,
+            price: None,
+            time_in_force: None,
+            max_show: None,
+            post_only: None,
+            reduce_only: None,
+            trigger_price: None,
+            trigger: None,
+            advanced: None,
+            mmp: None,
+            valid_until: None,
+        }
+    }
+
+    /// Set the order label
+    #[must_use]
+    pub fn with_label(mut self, label: String) -> Self {
+        self.label = Some(label);
+        self
+    }
+
+    /// Set time in force
+    #[must_use]
+    pub fn with_time_in_force(mut self, tif: TimeInForce) -> Self {
+        self.time_in_force = Some(tif);
+        self
+    }
+
+    /// Set post-only flag
+    #[must_use]
+    pub fn with_post_only(mut self, post_only: bool) -> Self {
+        self.post_only = Some(post_only);
+        self
+    }
+
+    /// Set reduce-only flag
+    #[must_use]
+    pub fn with_reduce_only(mut self, reduce_only: bool) -> Self {
+        self.reduce_only = Some(reduce_only);
+        self
+    }
+
+    /// Set max show amount for iceberg orders
+    #[must_use]
+    pub fn with_max_show(mut self, max_show: f64) -> Self {
+        self.max_show = Some(max_show);
+        self
+    }
+
+    /// Set trigger price for conditional orders
+    #[must_use]
+    pub fn with_trigger(mut self, trigger_price: f64, trigger: Trigger) -> Self {
+        self.trigger_price = Some(trigger_price);
+        self.trigger = Some(trigger);
+        self
+    }
+
+    /// Set MMP flag
+    #[must_use]
+    pub fn with_mmp(mut self, mmp: bool) -> Self {
+        self.mmp = Some(mmp);
+        self
+    }
+}
+
+/// Edit order request parameters
+#[derive(Clone, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+pub struct EditOrderRequest {
+    /// Order ID to edit
+    pub order_id: String,
+    /// New amount for the order
+    pub amount: f64,
+    /// New price for the order
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    /// Whether to only reduce the position
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_only: Option<bool>,
+    /// Whether this order only reduces position
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_only: Option<bool>,
+    /// Advanced order type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub advanced: Option<String>,
+    /// New trigger price for conditional orders
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+    /// Market maker protection flag
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mmp: Option<bool>,
+    /// Order validity timestamp
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<u64>,
+}
+
+impl EditOrderRequest {
+    /// Create a new edit order request
+    #[must_use]
+    pub fn new(order_id: String, amount: f64) -> Self {
+        Self {
+            order_id,
+            amount,
+            price: None,
+            post_only: None,
+            reduce_only: None,
+            advanced: None,
+            trigger_price: None,
+            mmp: None,
+            valid_until: None,
+        }
+    }
+
+    /// Set new price
+    #[must_use]
+    pub fn with_price(mut self, price: f64) -> Self {
+        self.price = Some(price);
+        self
+    }
+
+    /// Set post-only flag
+    #[must_use]
+    pub fn with_post_only(mut self, post_only: bool) -> Self {
+        self.post_only = Some(post_only);
+        self
+    }
+
+    /// Set reduce-only flag
+    #[must_use]
+    pub fn with_reduce_only(mut self, reduce_only: bool) -> Self {
+        self.reduce_only = Some(reduce_only);
+        self
+    }
+}
+
+/// Trade execution information
+#[derive(Clone, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+pub struct TradeExecution {
+    /// Trade ID
+    pub trade_id: String,
+    /// Instrument name
+    pub instrument_name: String,
+    /// Trade direction (buy/sell)
+    pub direction: String,
+    /// Trade amount
+    pub amount: f64,
+    /// Trade price
+    pub price: f64,
+    /// Trade fee
+    pub fee: f64,
+    /// Fee currency
+    pub fee_currency: String,
+    /// Order ID associated with this trade
+    pub order_id: String,
+    /// Order type
+    pub order_type: String,
+    /// Trade timestamp in milliseconds
+    pub timestamp: u64,
+    /// Liquidity type (maker/taker)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub liquidity: Option<String>,
+    /// Index price at time of trade
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_price: Option<f64>,
+    /// Mark price at time of trade
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mark_price: Option<f64>,
+    /// Profit/loss from the trade
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profit_loss: Option<f64>,
+}
+
+/// Order information response
+#[derive(Clone, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+pub struct OrderInfo {
+    /// Order ID
+    pub order_id: String,
+    /// Instrument name
+    pub instrument_name: String,
+    /// Order direction (buy/sell)
+    pub direction: String,
+    /// Order amount
+    pub amount: f64,
+    /// Filled amount
+    #[serde(default)]
+    pub filled_amount: f64,
+    /// Order price
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    /// Average fill price
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_price: Option<f64>,
+    /// Order type
+    pub order_type: String,
+    /// Order state (open, filled, cancelled, etc.)
+    pub order_state: String,
+    /// Time in force
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_in_force: Option<String>,
+    /// User label
+    #[serde(default)]
+    pub label: String,
+    /// Creation timestamp in milliseconds
+    pub creation_timestamp: u64,
+    /// Last update timestamp in milliseconds
+    pub last_update_timestamp: u64,
+    /// Whether placed via API
+    #[serde(default)]
+    pub api: bool,
+    /// Whether placed via web interface
+    #[serde(default)]
+    pub web: bool,
+    /// Whether this is a post-only order
+    #[serde(default)]
+    pub post_only: bool,
+    /// Whether this order only reduces position
+    #[serde(default)]
+    pub reduce_only: bool,
+    /// Whether this is a liquidation order
+    #[serde(default)]
+    pub is_liquidation: bool,
+    /// Maximum show amount
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_show: Option<f64>,
+    /// Profit/loss on this order
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profit_loss: Option<f64>,
+    /// USD value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usd: Option<f64>,
+    /// Implied volatility (for options)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implv: Option<f64>,
+    /// Trigger price for conditional orders
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+    /// Trigger type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger: Option<String>,
+    /// Whether triggered
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triggered: Option<bool>,
+    /// Whether replaced
+    #[serde(default)]
+    pub replaced: bool,
+    /// MMP flag
+    #[serde(default)]
+    pub mmp: bool,
+    /// MMP cancelled flag
+    #[serde(default)]
+    pub mmp_cancelled: bool,
+}
+
+/// Order response containing order info and trades
+#[derive(Clone, Serialize, Deserialize, DebugPretty, DisplaySimple)]
+pub struct OrderResponse {
+    /// Order information
+    pub order: OrderInfo,
+    /// List of trade executions for the order
+    #[serde(default)]
+    pub trades: Vec<TradeExecution>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_order_type_serialization() {
+        let order_type = OrderType::Limit;
+        let json = serde_json::to_string(&order_type).expect("serialize");
+        assert_eq!(json, "\"limit\"");
+
+        let order_type = OrderType::StopLimit;
+        let json = serde_json::to_string(&order_type).expect("serialize");
+        assert_eq!(json, "\"stop_limit\"");
+    }
+
+    #[test]
+    fn test_time_in_force_serialization() {
+        let tif = TimeInForce::GoodTilCancelled;
+        let json = serde_json::to_string(&tif).expect("serialize");
+        assert_eq!(json, "\"good_til_cancelled\"");
+
+        let tif = TimeInForce::ImmediateOrCancel;
+        let json = serde_json::to_string(&tif).expect("serialize");
+        assert_eq!(json, "\"immediate_or_cancel\"");
+    }
+
+    #[test]
+    fn test_order_request_limit() {
+        let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0)
+            .with_label("test_order".to_string())
+            .with_post_only(true);
+
+        assert_eq!(request.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(request.amount, 100.0);
+        assert_eq!(request.price, Some(50000.0));
+        assert_eq!(request.order_type, Some(OrderType::Limit));
+        assert_eq!(request.label, Some("test_order".to_string()));
+        assert_eq!(request.post_only, Some(true));
+    }
+
+    #[test]
+    fn test_order_request_market() {
+        let request =
+            OrderRequest::market("ETH-PERPETUAL".to_string(), 10.0).with_reduce_only(true);
+
+        assert_eq!(request.instrument_name, "ETH-PERPETUAL");
+        assert_eq!(request.amount, 10.0);
+        assert_eq!(request.price, None);
+        assert_eq!(request.order_type, Some(OrderType::Market));
+        assert_eq!(request.reduce_only, Some(true));
+    }
+
+    #[test]
+    fn test_edit_order_request() {
+        let request = EditOrderRequest::new("order123".to_string(), 200.0).with_price(51000.0);
+
+        assert_eq!(request.order_id, "order123");
+        assert_eq!(request.amount, 200.0);
+        assert_eq!(request.price, Some(51000.0));
+    }
+
+    #[test]
+    fn test_order_type_as_str() {
+        assert_eq!(OrderType::Limit.as_str(), "limit");
+        assert_eq!(OrderType::Market.as_str(), "market");
+        assert_eq!(OrderType::StopLimit.as_str(), "stop_limit");
+        assert_eq!(OrderType::TrailingStop.as_str(), "trailing_stop");
+    }
+
+    #[test]
+    fn test_time_in_force_as_str() {
+        assert_eq!(TimeInForce::GoodTilCancelled.as_str(), "good_til_cancelled");
+        assert_eq!(TimeInForce::FillOrKill.as_str(), "fill_or_kill");
+        assert_eq!(
+            TimeInForce::ImmediateOrCancel.as_str(),
+            "immediate_or_cancel"
+        );
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,6 +29,10 @@ pub use crate::model::{
         MmpGroupConfig, MmpGroupStatus, MmpTrigger, Quote, QuoteError, QuoteInfo,
     },
     subscription::{Subscription, SubscriptionManager},
+    trading::{
+        EditOrderRequest, OrderInfo, OrderRequest, OrderResponse, OrderType, TimeInForce,
+        TradeExecution, Trigger,
+    },
 };
 
 // Session management

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -12,3 +12,4 @@ pub mod message;
 pub mod model;
 pub mod session;
 pub mod subscriptions;
+pub mod trading;

--- a/tests/unit/trading.rs
+++ b/tests/unit/trading.rs
@@ -1,0 +1,451 @@
+//! Unit tests for trading module
+
+use deribit_websocket::prelude::*;
+
+#[test]
+fn test_order_request_limit() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0);
+
+    assert_eq!(request.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(request.amount, 100.0);
+    assert_eq!(request.price, Some(50000.0));
+    assert_eq!(request.order_type, Some(OrderType::Limit));
+}
+
+#[test]
+fn test_order_request_market() {
+    let request = OrderRequest::market("ETH-PERPETUAL".to_string(), 10.0);
+
+    assert_eq!(request.instrument_name, "ETH-PERPETUAL");
+    assert_eq!(request.amount, 10.0);
+    assert_eq!(request.price, None);
+    assert_eq!(request.order_type, Some(OrderType::Market));
+}
+
+#[test]
+fn test_order_request_with_label() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0)
+        .with_label("test_order".to_string());
+
+    assert_eq!(request.label, Some("test_order".to_string()));
+}
+
+#[test]
+fn test_order_request_with_time_in_force() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0)
+        .with_time_in_force(TimeInForce::GoodTilCancelled);
+
+    assert_eq!(request.time_in_force, Some(TimeInForce::GoodTilCancelled));
+}
+
+#[test]
+fn test_order_request_with_post_only() {
+    let request =
+        OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0).with_post_only(true);
+
+    assert_eq!(request.post_only, Some(true));
+}
+
+#[test]
+fn test_order_request_with_reduce_only() {
+    let request = OrderRequest::market("BTC-PERPETUAL".to_string(), 100.0).with_reduce_only(true);
+
+    assert_eq!(request.reduce_only, Some(true));
+}
+
+#[test]
+fn test_order_request_with_max_show() {
+    let request =
+        OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0).with_max_show(10.0);
+
+    assert_eq!(request.max_show, Some(10.0));
+}
+
+#[test]
+fn test_order_request_with_trigger() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0)
+        .with_trigger(49000.0, Trigger::MarkPrice);
+
+    assert_eq!(request.trigger_price, Some(49000.0));
+    assert_eq!(request.trigger, Some(Trigger::MarkPrice));
+}
+
+#[test]
+fn test_order_request_with_mmp() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0).with_mmp(true);
+
+    assert_eq!(request.mmp, Some(true));
+}
+
+#[test]
+fn test_order_request_chained_builders() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0)
+        .with_label("my_order".to_string())
+        .with_post_only(true)
+        .with_time_in_force(TimeInForce::ImmediateOrCancel)
+        .with_mmp(true);
+
+    assert_eq!(request.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(request.amount, 100.0);
+    assert_eq!(request.price, Some(50000.0));
+    assert_eq!(request.label, Some("my_order".to_string()));
+    assert_eq!(request.post_only, Some(true));
+    assert_eq!(request.time_in_force, Some(TimeInForce::ImmediateOrCancel));
+    assert_eq!(request.mmp, Some(true));
+}
+
+#[test]
+fn test_edit_order_request() {
+    let request = EditOrderRequest::new("order123".to_string(), 200.0);
+
+    assert_eq!(request.order_id, "order123");
+    assert_eq!(request.amount, 200.0);
+    assert_eq!(request.price, None);
+}
+
+#[test]
+fn test_edit_order_request_with_price() {
+    let request = EditOrderRequest::new("order123".to_string(), 200.0).with_price(51000.0);
+
+    assert_eq!(request.order_id, "order123");
+    assert_eq!(request.amount, 200.0);
+    assert_eq!(request.price, Some(51000.0));
+}
+
+#[test]
+fn test_edit_order_request_with_post_only() {
+    let request = EditOrderRequest::new("order123".to_string(), 200.0).with_post_only(true);
+
+    assert_eq!(request.post_only, Some(true));
+}
+
+#[test]
+fn test_edit_order_request_with_reduce_only() {
+    let request = EditOrderRequest::new("order123".to_string(), 200.0).with_reduce_only(true);
+
+    assert_eq!(request.reduce_only, Some(true));
+}
+
+#[test]
+fn test_edit_order_request_chained() {
+    let request = EditOrderRequest::new("order456".to_string(), 300.0)
+        .with_price(52000.0)
+        .with_post_only(true)
+        .with_reduce_only(false);
+
+    assert_eq!(request.order_id, "order456");
+    assert_eq!(request.amount, 300.0);
+    assert_eq!(request.price, Some(52000.0));
+    assert_eq!(request.post_only, Some(true));
+    assert_eq!(request.reduce_only, Some(false));
+}
+
+#[test]
+fn test_order_type_as_str() {
+    assert_eq!(OrderType::Limit.as_str(), "limit");
+    assert_eq!(OrderType::Market.as_str(), "market");
+    assert_eq!(OrderType::StopLimit.as_str(), "stop_limit");
+    assert_eq!(OrderType::StopMarket.as_str(), "stop_market");
+    assert_eq!(OrderType::TakeLimit.as_str(), "take_limit");
+    assert_eq!(OrderType::TakeMarket.as_str(), "take_market");
+    assert_eq!(OrderType::MarketLimit.as_str(), "market_limit");
+    assert_eq!(OrderType::TrailingStop.as_str(), "trailing_stop");
+}
+
+#[test]
+fn test_time_in_force_as_str() {
+    assert_eq!(TimeInForce::GoodTilCancelled.as_str(), "good_til_cancelled");
+    assert_eq!(TimeInForce::GoodTilDay.as_str(), "good_til_day");
+    assert_eq!(TimeInForce::FillOrKill.as_str(), "fill_or_kill");
+    assert_eq!(
+        TimeInForce::ImmediateOrCancel.as_str(),
+        "immediate_or_cancel"
+    );
+}
+
+#[test]
+fn test_order_type_serialization() {
+    let order_type = OrderType::Limit;
+    let json = serde_json::to_string(&order_type).expect("serialize");
+    assert_eq!(json, "\"limit\"");
+
+    let order_type = OrderType::StopLimit;
+    let json = serde_json::to_string(&order_type).expect("serialize");
+    assert_eq!(json, "\"stop_limit\"");
+}
+
+#[test]
+fn test_order_type_deserialization() {
+    let order_type: OrderType = serde_json::from_str("\"limit\"").expect("deserialize");
+    assert_eq!(order_type, OrderType::Limit);
+
+    let order_type: OrderType = serde_json::from_str("\"stop_market\"").expect("deserialize");
+    assert_eq!(order_type, OrderType::StopMarket);
+}
+
+#[test]
+fn test_time_in_force_serialization() {
+    let tif = TimeInForce::GoodTilCancelled;
+    let json = serde_json::to_string(&tif).expect("serialize");
+    assert_eq!(json, "\"good_til_cancelled\"");
+
+    let tif = TimeInForce::ImmediateOrCancel;
+    let json = serde_json::to_string(&tif).expect("serialize");
+    assert_eq!(json, "\"immediate_or_cancel\"");
+}
+
+#[test]
+fn test_time_in_force_deserialization() {
+    let tif: TimeInForce = serde_json::from_str("\"good_til_cancelled\"").expect("deserialize");
+    assert_eq!(tif, TimeInForce::GoodTilCancelled);
+
+    let tif: TimeInForce = serde_json::from_str("\"fill_or_kill\"").expect("deserialize");
+    assert_eq!(tif, TimeInForce::FillOrKill);
+}
+
+#[test]
+fn test_trigger_serialization() {
+    let trigger = Trigger::IndexPrice;
+    let json = serde_json::to_string(&trigger).expect("serialize");
+    assert_eq!(json, "\"index_price\"");
+
+    let trigger = Trigger::MarkPrice;
+    let json = serde_json::to_string(&trigger).expect("serialize");
+    assert_eq!(json, "\"mark_price\"");
+}
+
+#[test]
+fn test_trigger_deserialization() {
+    let trigger: Trigger = serde_json::from_str("\"index_price\"").expect("deserialize");
+    assert_eq!(trigger, Trigger::IndexPrice);
+
+    let trigger: Trigger = serde_json::from_str("\"last_price\"").expect("deserialize");
+    assert_eq!(trigger, Trigger::LastPrice);
+}
+
+#[test]
+fn test_order_request_serialization() {
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0)
+        .with_label("test".to_string())
+        .with_post_only(true);
+
+    let json = serde_json::to_value(&request).expect("serialize");
+
+    assert_eq!(json["instrument_name"], "BTC-PERPETUAL");
+    assert_eq!(json["amount"], 100.0);
+    assert_eq!(json["price"], 50000.0);
+    assert_eq!(json["type"], "limit");
+    assert_eq!(json["label"], "test");
+    assert_eq!(json["post_only"], true);
+}
+
+#[test]
+fn test_edit_order_request_serialization() {
+    let request = EditOrderRequest::new("order123".to_string(), 200.0).with_price(51000.0);
+
+    let json = serde_json::to_value(&request).expect("serialize");
+
+    assert_eq!(json["order_id"], "order123");
+    assert_eq!(json["amount"], 200.0);
+    assert_eq!(json["price"], 51000.0);
+}
+
+#[test]
+fn test_order_info_deserialization() {
+    let json = r#"{
+        "order_id": "123456",
+        "instrument_name": "BTC-PERPETUAL",
+        "direction": "buy",
+        "amount": 100.0,
+        "filled_amount": 50.0,
+        "price": 50000.0,
+        "average_price": 49950.0,
+        "order_type": "limit",
+        "order_state": "open",
+        "label": "test",
+        "creation_timestamp": 1609459200000,
+        "last_update_timestamp": 1609459200000,
+        "api": true,
+        "web": false,
+        "post_only": true,
+        "reduce_only": false,
+        "is_liquidation": false,
+        "replaced": false,
+        "mmp": false,
+        "mmp_cancelled": false
+    }"#;
+
+    let order_info: OrderInfo = serde_json::from_str(json).expect("deserialize");
+
+    assert_eq!(order_info.order_id, "123456");
+    assert_eq!(order_info.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(order_info.direction, "buy");
+    assert_eq!(order_info.amount, 100.0);
+    assert_eq!(order_info.filled_amount, 50.0);
+    assert_eq!(order_info.price, Some(50000.0));
+    assert_eq!(order_info.order_state, "open");
+    assert!(order_info.api);
+    assert!(order_info.post_only);
+}
+
+#[test]
+fn test_order_response_deserialization() {
+    let json = r#"{
+        "order": {
+            "order_id": "123456",
+            "instrument_name": "BTC-PERPETUAL",
+            "direction": "buy",
+            "amount": 100.0,
+            "filled_amount": 0.0,
+            "price": 50000.0,
+            "order_type": "limit",
+            "order_state": "open",
+            "label": "",
+            "creation_timestamp": 1609459200000,
+            "last_update_timestamp": 1609459200000,
+            "api": true,
+            "web": false,
+            "post_only": false,
+            "reduce_only": false,
+            "is_liquidation": false,
+            "replaced": false,
+            "mmp": false,
+            "mmp_cancelled": false
+        },
+        "trades": []
+    }"#;
+
+    let response: OrderResponse = serde_json::from_str(json).expect("deserialize");
+
+    assert_eq!(response.order.order_id, "123456");
+    assert_eq!(response.order.instrument_name, "BTC-PERPETUAL");
+    assert!(response.trades.is_empty());
+}
+
+#[test]
+fn test_trade_execution_deserialization() {
+    let json = r#"{
+        "trade_id": "trade123",
+        "instrument_name": "BTC-PERPETUAL",
+        "direction": "buy",
+        "amount": 50.0,
+        "price": 49950.0,
+        "fee": 0.0001,
+        "fee_currency": "BTC",
+        "order_id": "order123",
+        "order_type": "limit",
+        "timestamp": 1609459200000,
+        "liquidity": "maker",
+        "index_price": 50000.0,
+        "mark_price": 49980.0
+    }"#;
+
+    let trade: TradeExecution = serde_json::from_str(json).expect("deserialize");
+
+    assert_eq!(trade.trade_id, "trade123");
+    assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(trade.direction, "buy");
+    assert_eq!(trade.amount, 50.0);
+    assert_eq!(trade.price, 49950.0);
+    assert_eq!(trade.fee, 0.0001);
+    assert_eq!(trade.liquidity, Some("maker".to_string()));
+}
+
+#[test]
+fn test_request_builder_buy() {
+    let mut builder = RequestBuilder::new();
+    let order_request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0);
+    let request = builder.build_buy_request(&order_request);
+
+    assert_eq!(request.method, "private/buy");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["instrument_name"], "BTC-PERPETUAL");
+    assert_eq!(params["amount"], 100.0);
+}
+
+#[test]
+fn test_request_builder_sell() {
+    let mut builder = RequestBuilder::new();
+    let order_request = OrderRequest::limit("ETH-PERPETUAL".to_string(), 10.0, 3000.0);
+    let request = builder.build_sell_request(&order_request);
+
+    assert_eq!(request.method, "private/sell");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["instrument_name"], "ETH-PERPETUAL");
+    assert_eq!(params["amount"], 10.0);
+}
+
+#[test]
+fn test_request_builder_cancel() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_cancel_request("order123");
+
+    assert_eq!(request.method, "private/cancel");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["order_id"], "order123");
+}
+
+#[test]
+fn test_request_builder_cancel_all() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_cancel_all_request();
+
+    assert_eq!(request.method, "private/cancel_all");
+}
+
+#[test]
+fn test_request_builder_cancel_all_by_currency() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_cancel_all_by_currency_request("BTC");
+
+    assert_eq!(request.method, "private/cancel_all_by_currency");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["currency"], "BTC");
+}
+
+#[test]
+fn test_request_builder_cancel_all_by_instrument() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_cancel_all_by_instrument_request("BTC-PERPETUAL");
+
+    assert_eq!(request.method, "private/cancel_all_by_instrument");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["instrument_name"], "BTC-PERPETUAL");
+}
+
+#[test]
+fn test_request_builder_edit() {
+    let mut builder = RequestBuilder::new();
+    let edit_request = EditOrderRequest::new("order123".to_string(), 200.0).with_price(51000.0);
+    let request = builder.build_edit_request(&edit_request);
+
+    assert_eq!(request.method, "private/edit");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["order_id"], "order123");
+    assert_eq!(params["amount"], 200.0);
+}
+
+#[test]
+fn test_request_builder_incremental_ids() {
+    let mut builder = RequestBuilder::new();
+
+    let r1 = builder.build_cancel_all_request();
+    let r2 = builder.build_cancel_all_request();
+    let r3 = builder.build_cancel_all_request();
+
+    assert_eq!(r1.id, serde_json::json!(1));
+    assert_eq!(r2.id, serde_json::json!(2));
+    assert_eq!(r3.id, serde_json::json!(3));
+}


### PR DESCRIPTION
## Summary

Implement typed WebSocket methods for core trading operations. This adds buy, sell, cancel, cancel_all, and edit order functionality.

## Changes

### New Files
- `src/model/trading.rs` - Trading types (OrderRequest, EditOrderRequest, OrderResponse, OrderInfo, OrderType, TimeInForce, Trigger, TradeExecution)
- `tests/unit/trading.rs` - 36 unit tests for trading module

### Modified Files
- `src/client.rs` - Added 7 new trading methods
- `src/message/request.rs` - Added request builders for all trading operations
- `src/constants.rs` - Added missing method constants
- `src/model/mod.rs` - Export trading module
- `src/prelude.rs` - Export trading types
- `CHANGELOG.md` - Document new features

## New Methods on `DeribitWebSocketClient`

| Method | Description | Return Type |
|--------|-------------|-------------|
| `buy(OrderRequest)` | Place a buy order | `OrderResponse` |
| `sell(OrderRequest)` | Place a sell order | `OrderResponse` |
| `cancel(order_id)` | Cancel specific order | `OrderInfo` |
| `cancel_all()` | Cancel all orders | `u32` |
| `cancel_all_by_currency(currency)` | Cancel all by currency | `u32` |
| `cancel_all_by_instrument(instrument)` | Cancel all by instrument | `u32` |
| `edit(EditOrderRequest)` | Modify existing order | `OrderResponse` |

## Testing

- [x] 137 tests pass (17 lib + 115 unit + 5 doc tests)
- [x] 36 new trading tests added
- [x] `make lint-fix` passes
- [x] `make pre-push` passes

## Checklist

- [x] All trading methods implemented
- [x] Request builders for all operations
- [x] Comprehensive test coverage
- [x] Types exported in prelude
- [x] Documentation on all public items
- [x] CHANGELOG updated

Closes #5
