### PR TITLE
M2 #8: Implement close_position and move_positions over WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account types: `Position`, `AccountSummary`, `CurrencySummary`, `Direction`
 - Request builders for all account operations
 - Comprehensive unit tests for account module (25+ tests)
+- Position management methods over WebSocket: `close_position()`, `move_positions()`
+- Position types: `ClosePositionResponse`, `CloseTrade`, `CloseOrder`, `MovePositionTrade`, `MovePositionResult`
+- Request builders for position management operations
+- Comprehensive unit tests for position module (25+ tests)
 
 ### Fixed
 - `parse_channel_type()` now correctly handles all 14 `SubscriptionChannel` variants instead of only 5

--- a/src/client.rs
+++ b/src/client.rs
@@ -744,6 +744,96 @@ impl DeribitWebSocketClient {
         }
     }
 
+    // Position management methods
+
+    /// Close an existing position
+    ///
+    /// Places a reduce-only order to close an existing position.
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - The instrument to close position for
+    /// * `order_type` - Order type: "limit" or "market"
+    /// * `price` - Price for limit orders (required if order_type is "limit")
+    ///
+    /// # Returns
+    ///
+    /// Response containing the order and any trades executed
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response cannot be parsed
+    pub async fn close_position(
+        &self,
+        instrument_name: &str,
+        order_type: &str,
+        price: Option<f64>,
+    ) -> Result<crate::model::ClosePositionResponse, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_close_position_request(instrument_name, order_type, price)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!(
+                    "Failed to parse close position response: {}",
+                    e
+                ))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Move positions between subaccounts
+    ///
+    /// Transfers positions from one subaccount to another within the same main account.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency for the positions (BTC, ETH, etc.)
+    /// * `source_uid` - Source subaccount ID
+    /// * `target_uid` - Target subaccount ID
+    /// * `trades` - List of positions to move
+    ///
+    /// # Returns
+    ///
+    /// A vector of results for each position moved
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response cannot be parsed
+    pub async fn move_positions(
+        &self,
+        currency: &str,
+        source_uid: u64,
+        target_uid: u64,
+        trades: &[crate::model::MovePositionTrade],
+    ) -> Result<Vec<crate::model::MovePositionResult>, WebSocketError> {
+        let json_request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_move_positions_request(currency, source_uid, target_uid, trades)
+        };
+
+        let response = self.send_request(json_request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => serde_json::from_value(result).map_err(|e| {
+                WebSocketError::InvalidMessage(format!(
+                    "Failed to parse move positions response: {}",
+                    e
+                ))
+            }),
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
     /// Set message handler with callbacks
     /// The message_callback processes each incoming message and returns Result<(), Error>
     /// The error_callback is called only when message_callback returns an error

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -69,6 +69,12 @@ pub mod methods {
     /// Get order history by currency
     pub const PRIVATE_GET_ORDER_HISTORY_BY_CURRENCY: &str = "private/get_order_history_by_currency";
 
+    // Position management
+    /// Close an existing position
+    pub const PRIVATE_CLOSE_POSITION: &str = "private/close_position";
+    /// Move positions between subaccounts
+    pub const PRIVATE_MOVE_POSITIONS: &str = "private/move_positions";
+
     // Test
     /// Test connection
     pub const PUBLIC_TEST: &str = "public/test";

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -483,4 +483,97 @@ impl RequestBuilder {
             Some(serde_json::Value::Object(params)),
         )
     }
+
+    // Position management methods
+
+    /// Build a close_position request
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - The instrument to close position for
+    /// * `order_type` - Order type: "limit" or "market"
+    /// * `price` - Price for limit orders (required if order_type is "limit")
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for closing a position
+    pub fn build_close_position_request(
+        &mut self,
+        instrument_name: &str,
+        order_type: &str,
+        price: Option<f64>,
+    ) -> JsonRpcRequest {
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "instrument_name".to_string(),
+            serde_json::Value::String(instrument_name.to_string()),
+        );
+        params.insert(
+            "type".to_string(),
+            serde_json::Value::String(order_type.to_string()),
+        );
+
+        if let Some(price) = price
+            && let Some(price_num) = serde_json::Number::from_f64(price)
+        {
+            params.insert("price".to_string(), serde_json::Value::Number(price_num));
+        }
+
+        self.build_request(
+            crate::constants::methods::PRIVATE_CLOSE_POSITION,
+            Some(serde_json::Value::Object(params)),
+        )
+    }
+
+    /// Build a move_positions request
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency for the positions (BTC, ETH, etc.)
+    /// * `source_uid` - Source subaccount ID
+    /// * `target_uid` - Target subaccount ID
+    /// * `trades` - List of positions to move
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for moving positions between subaccounts
+    pub fn build_move_positions_request(
+        &mut self,
+        currency: &str,
+        source_uid: u64,
+        target_uid: u64,
+        trades: &[crate::model::MovePositionTrade],
+    ) -> JsonRpcRequest {
+        let trades_json: Vec<serde_json::Value> = trades
+            .iter()
+            .map(|t| {
+                let mut trade_obj = serde_json::Map::new();
+                trade_obj.insert(
+                    "instrument_name".to_string(),
+                    serde_json::Value::String(t.instrument_name.clone()),
+                );
+                if let Some(amount_num) = serde_json::Number::from_f64(t.amount) {
+                    trade_obj.insert("amount".to_string(), serde_json::Value::Number(amount_num));
+                }
+                if let Some(price) = t.price
+                    && let Some(price_num) = serde_json::Number::from_f64(price)
+                {
+                    trade_obj.insert("price".to_string(), serde_json::Value::Number(price_num));
+                }
+                serde_json::Value::Object(trade_obj)
+            })
+            .collect();
+
+        let params = serde_json::json!({
+            "currency": currency,
+            "source_uid": source_uid,
+            "target_uid": target_uid,
+            "trades": trades_json
+        });
+
+        self.build_request(
+            crate::constants::methods::PRIVATE_MOVE_POSITIONS,
+            Some(params),
+        )
+    }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,12 +1,14 @@
 //! Model definitions for WebSocket client
 
 pub mod account;
+pub mod position;
 pub mod quote;
 pub mod subscription;
 pub mod trading;
 pub mod ws_types;
 
 pub use account::*;
+pub use position::*;
 pub use quote::*;
 pub use subscription::*;
 pub use trading::*;

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -1,0 +1,345 @@
+//! Position management model definitions for Deribit WebSocket API
+//!
+//! This module provides types for position management operations including
+//! closing positions and moving positions between subaccounts.
+
+use serde::{Deserialize, Serialize};
+
+/// Trade information from a close_position response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloseTrade {
+    /// Trade sequence number
+    #[serde(default)]
+    pub trade_seq: Option<u64>,
+    /// Unique trade identifier
+    #[serde(default)]
+    pub trade_id: Option<String>,
+    /// Trade timestamp in milliseconds
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+    /// Tick direction (0, 1, 2, 3)
+    #[serde(default)]
+    pub tick_direction: Option<i32>,
+    /// Trade state (filled, etc.)
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Whether this was a reduce-only trade
+    #[serde(default)]
+    pub reduce_only: Option<bool>,
+    /// Trade price
+    #[serde(default)]
+    pub price: Option<f64>,
+    /// Whether this was a post-only order
+    #[serde(default)]
+    pub post_only: Option<bool>,
+    /// Order type (limit, market)
+    #[serde(default)]
+    pub order_type: Option<String>,
+    /// Order ID
+    #[serde(default)]
+    pub order_id: Option<String>,
+    /// Matching ID
+    #[serde(default)]
+    pub matching_id: Option<String>,
+    /// Mark price at time of trade
+    #[serde(default)]
+    pub mark_price: Option<f64>,
+    /// Liquidity type (T = taker, M = maker)
+    #[serde(default)]
+    pub liquidity: Option<String>,
+    /// Instrument name
+    #[serde(default)]
+    pub instrument_name: Option<String>,
+    /// Index price at time of trade
+    #[serde(default)]
+    pub index_price: Option<f64>,
+    /// Fee currency
+    #[serde(default)]
+    pub fee_currency: Option<String>,
+    /// Fee amount
+    #[serde(default)]
+    pub fee: Option<f64>,
+    /// Trade direction (buy/sell)
+    #[serde(default)]
+    pub direction: Option<String>,
+    /// Trade amount
+    #[serde(default)]
+    pub amount: Option<f64>,
+}
+
+/// Order information from a close_position response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloseOrder {
+    /// Whether the order was created via web
+    #[serde(default)]
+    pub web: Option<bool>,
+    /// Time in force
+    #[serde(default)]
+    pub time_in_force: Option<String>,
+    /// Whether the order was replaced
+    #[serde(default)]
+    pub replaced: Option<bool>,
+    /// Whether this is a reduce-only order
+    #[serde(default)]
+    pub reduce_only: Option<bool>,
+    /// Order price
+    #[serde(default)]
+    pub price: Option<f64>,
+    /// Whether this is a post-only order
+    #[serde(default)]
+    pub post_only: Option<bool>,
+    /// Order type (limit, market)
+    #[serde(default)]
+    pub order_type: Option<String>,
+    /// Order state (open, filled, cancelled)
+    #[serde(default)]
+    pub order_state: Option<String>,
+    /// Order ID
+    #[serde(default)]
+    pub order_id: Option<String>,
+    /// Maximum display amount
+    #[serde(default)]
+    pub max_show: Option<f64>,
+    /// Last update timestamp
+    #[serde(default)]
+    pub last_update_timestamp: Option<u64>,
+    /// Order label
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Whether this is a rebalance order
+    #[serde(default)]
+    pub is_rebalance: Option<bool>,
+    /// Whether this is a liquidation order
+    #[serde(default)]
+    pub is_liquidation: Option<bool>,
+    /// Instrument name
+    #[serde(default)]
+    pub instrument_name: Option<String>,
+    /// Filled amount
+    #[serde(default)]
+    pub filled_amount: Option<f64>,
+    /// Order direction (buy/sell)
+    #[serde(default)]
+    pub direction: Option<String>,
+    /// Creation timestamp
+    #[serde(default)]
+    pub creation_timestamp: Option<u64>,
+    /// Average fill price
+    #[serde(default)]
+    pub average_price: Option<f64>,
+    /// Whether created via API
+    #[serde(default)]
+    pub api: Option<bool>,
+    /// Order amount
+    #[serde(default)]
+    pub amount: Option<f64>,
+}
+
+/// Response from close_position API call
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClosePositionResponse {
+    /// List of trades executed to close the position
+    #[serde(default)]
+    pub trades: Vec<CloseTrade>,
+    /// The order placed to close the position
+    #[serde(default)]
+    pub order: Option<CloseOrder>,
+}
+
+/// Trade specification for move_positions request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MovePositionTrade {
+    /// Instrument name (e.g., "BTC-PERPETUAL")
+    pub instrument_name: String,
+    /// Amount to move
+    pub amount: f64,
+    /// Optional price at which to move the position
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+}
+
+impl MovePositionTrade {
+    /// Create a new move position trade
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - The instrument name
+    /// * `amount` - The amount to move
+    #[must_use]
+    pub fn new(instrument_name: &str, amount: f64) -> Self {
+        Self {
+            instrument_name: instrument_name.to_string(),
+            amount,
+            price: None,
+        }
+    }
+
+    /// Set the price for the position move
+    #[must_use]
+    pub fn with_price(mut self, price: f64) -> Self {
+        self.price = Some(price);
+        self
+    }
+}
+
+/// Result of a single position move
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MovePositionResult {
+    /// Target subaccount ID
+    pub target_uid: u64,
+    /// Source subaccount ID
+    pub source_uid: u64,
+    /// Price at which the position was moved
+    pub price: f64,
+    /// Instrument name
+    pub instrument_name: String,
+    /// Direction of the position (buy/sell)
+    pub direction: String,
+    /// Amount that was moved
+    pub amount: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_move_position_trade_new() {
+        let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(trade.amount, 100.0);
+        assert!(trade.price.is_none());
+    }
+
+    #[test]
+    fn test_move_position_trade_with_price() {
+        let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0).with_price(50000.0);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(trade.amount, 100.0);
+        assert_eq!(trade.price, Some(50000.0));
+    }
+
+    #[test]
+    fn test_move_position_trade_serialization() {
+        let trade = MovePositionTrade::new("ETH-PERPETUAL", 50.0).with_price(3000.0);
+        let json = serde_json::to_string(&trade).expect("serialize");
+        assert!(json.contains("ETH-PERPETUAL"));
+        assert!(json.contains("50"));
+        assert!(json.contains("3000"));
+    }
+
+    #[test]
+    fn test_move_position_trade_without_price_serialization() {
+        let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0);
+        let json = serde_json::to_string(&trade).expect("serialize");
+        assert!(!json.contains("price"));
+    }
+
+    #[test]
+    fn test_move_position_result_deserialization() {
+        let json = r#"{
+            "target_uid": 23,
+            "source_uid": 3,
+            "price": 35800.0,
+            "instrument_name": "BTC-PERPETUAL",
+            "direction": "buy",
+            "amount": 110.0
+        }"#;
+
+        let result: MovePositionResult = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(result.target_uid, 23);
+        assert_eq!(result.source_uid, 3);
+        assert_eq!(result.price, 35800.0);
+        assert_eq!(result.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(result.direction, "buy");
+        assert_eq!(result.amount, 110.0);
+    }
+
+    #[test]
+    fn test_close_position_response_deserialization() {
+        let json = r#"{
+            "trades": [{
+                "trade_seq": 1966068,
+                "trade_id": "ETH-2696097",
+                "timestamp": 1590486335742,
+                "tick_direction": 0,
+                "state": "filled",
+                "reduce_only": true,
+                "price": 202.8,
+                "post_only": false,
+                "order_type": "limit",
+                "order_id": "ETH-584864807",
+                "mark_price": 202.79,
+                "liquidity": "T",
+                "instrument_name": "ETH-PERPETUAL",
+                "index_price": 202.86,
+                "fee_currency": "ETH",
+                "fee": 0.00007766,
+                "direction": "sell",
+                "amount": 21.0
+            }],
+            "order": {
+                "time_in_force": "good_til_cancelled",
+                "reduce_only": true,
+                "price": 198.75,
+                "post_only": false,
+                "order_type": "limit",
+                "order_state": "filled",
+                "order_id": "ETH-584864807",
+                "instrument_name": "ETH-PERPETUAL",
+                "filled_amount": 21.0,
+                "direction": "sell",
+                "creation_timestamp": 1590486335742,
+                "average_price": 202.8,
+                "api": true,
+                "amount": 21.0
+            }
+        }"#;
+
+        let response: ClosePositionResponse = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(response.trades.len(), 1);
+        assert!(response.order.is_some());
+
+        let trade = &response.trades[0];
+        assert_eq!(trade.trade_id, Some("ETH-2696097".to_string()));
+        assert_eq!(trade.price, Some(202.8));
+        assert_eq!(trade.direction, Some("sell".to_string()));
+
+        let order = response.order.as_ref().expect("order");
+        assert_eq!(order.order_id, Some("ETH-584864807".to_string()));
+        assert_eq!(order.order_state, Some("filled".to_string()));
+    }
+
+    #[test]
+    fn test_close_trade_deserialization() {
+        let json = r#"{
+            "trade_seq": 12345,
+            "trade_id": "BTC-123456",
+            "price": 50000.0,
+            "amount": 1.0,
+            "direction": "buy"
+        }"#;
+
+        let trade: CloseTrade = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(trade.trade_seq, Some(12345));
+        assert_eq!(trade.trade_id, Some("BTC-123456".to_string()));
+        assert_eq!(trade.price, Some(50000.0));
+    }
+
+    #[test]
+    fn test_close_order_deserialization() {
+        let json = r#"{
+            "order_id": "BTC-123",
+            "order_state": "open",
+            "order_type": "limit",
+            "price": 45000.0,
+            "amount": 100.0,
+            "direction": "sell"
+        }"#;
+
+        let order: CloseOrder = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(order.order_id, Some("BTC-123".to_string()));
+        assert_eq!(order.order_state, Some("open".to_string()));
+        assert_eq!(order.price, Some(45000.0));
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,6 +25,9 @@ pub use crate::message::{
 // Model types
 pub use crate::model::{
     account::{AccountSummary, CurrencySummary, Direction, Position},
+    position::{
+        CloseOrder, ClosePositionResponse, CloseTrade, MovePositionResult, MovePositionTrade,
+    },
     quote::{
         CancelQuotesRequest, CancelQuotesResponse, MassQuoteRequest, MassQuoteResult,
         MmpGroupConfig, MmpGroupStatus, MmpTrigger, Quote, QuoteError, QuoteInfo,

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -11,6 +11,7 @@ pub mod connection;
 pub mod error;
 pub mod message;
 pub mod model;
+pub mod position;
 pub mod session;
 pub mod subscription_channel;
 pub mod subscriptions;

--- a/tests/unit/position.rs
+++ b/tests/unit/position.rs
@@ -1,0 +1,331 @@
+//! Unit tests for position management module
+
+use deribit_websocket::prelude::*;
+
+// MovePositionTrade tests
+
+#[test]
+fn test_move_position_trade_new() {
+    let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0);
+    assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(trade.amount, 100.0);
+    assert!(trade.price.is_none());
+}
+
+#[test]
+fn test_move_position_trade_with_price() {
+    let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0).with_price(50000.0);
+    assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(trade.amount, 100.0);
+    assert_eq!(trade.price, Some(50000.0));
+}
+
+#[test]
+fn test_move_position_trade_chained() {
+    let trade = MovePositionTrade::new("ETH-PERPETUAL", 50.0).with_price(3000.0);
+    assert_eq!(trade.instrument_name, "ETH-PERPETUAL");
+    assert_eq!(trade.amount, 50.0);
+    assert_eq!(trade.price, Some(3000.0));
+}
+
+#[test]
+fn test_move_position_trade_serialization() {
+    let trade = MovePositionTrade::new("ETH-PERPETUAL", 50.0).with_price(3000.0);
+    let json = serde_json::to_string(&trade).expect("serialize");
+    assert!(json.contains("ETH-PERPETUAL"));
+    assert!(json.contains("50"));
+    assert!(json.contains("3000"));
+}
+
+#[test]
+fn test_move_position_trade_without_price_serialization() {
+    let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0);
+    let json = serde_json::to_string(&trade).expect("serialize");
+    assert!(json.contains("BTC-PERPETUAL"));
+    assert!(json.contains("100"));
+    // price should not be serialized when None
+    assert!(!json.contains("price"));
+}
+
+#[test]
+fn test_move_position_trade_deserialization() {
+    let json = r#"{
+        "instrument_name": "BTC-PERPETUAL",
+        "amount": 100.0,
+        "price": 45000.0
+    }"#;
+
+    let trade: MovePositionTrade = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(trade.amount, 100.0);
+    assert_eq!(trade.price, Some(45000.0));
+}
+
+// MovePositionResult tests
+
+#[test]
+fn test_move_position_result_deserialization() {
+    let json = r#"{
+        "target_uid": 23,
+        "source_uid": 3,
+        "price": 35800.0,
+        "instrument_name": "BTC-PERPETUAL",
+        "direction": "buy",
+        "amount": 110.0
+    }"#;
+
+    let result: MovePositionResult = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(result.target_uid, 23);
+    assert_eq!(result.source_uid, 3);
+    assert_eq!(result.price, 35800.0);
+    assert_eq!(result.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(result.direction, "buy");
+    assert_eq!(result.amount, 110.0);
+}
+
+#[test]
+fn test_move_position_result_sell_direction() {
+    let json = r#"{
+        "target_uid": 10,
+        "source_uid": 5,
+        "price": 0.1223,
+        "instrument_name": "BTC-28JAN22-32500-C",
+        "direction": "sell",
+        "amount": 0.1
+    }"#;
+
+    let result: MovePositionResult = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(result.direction, "sell");
+    assert_eq!(result.instrument_name, "BTC-28JAN22-32500-C");
+}
+
+// ClosePositionResponse tests
+
+#[test]
+fn test_close_position_response_deserialization() {
+    let json = r#"{
+        "trades": [{
+            "trade_seq": 1966068,
+            "trade_id": "ETH-2696097",
+            "timestamp": 1590486335742,
+            "tick_direction": 0,
+            "state": "filled",
+            "reduce_only": true,
+            "price": 202.8,
+            "post_only": false,
+            "order_type": "limit",
+            "order_id": "ETH-584864807",
+            "mark_price": 202.79,
+            "liquidity": "T",
+            "instrument_name": "ETH-PERPETUAL",
+            "index_price": 202.86,
+            "fee_currency": "ETH",
+            "fee": 0.00007766,
+            "direction": "sell",
+            "amount": 21.0
+        }],
+        "order": {
+            "time_in_force": "good_til_cancelled",
+            "reduce_only": true,
+            "price": 198.75,
+            "post_only": false,
+            "order_type": "limit",
+            "order_state": "filled",
+            "order_id": "ETH-584864807",
+            "instrument_name": "ETH-PERPETUAL",
+            "filled_amount": 21.0,
+            "direction": "sell",
+            "creation_timestamp": 1590486335742,
+            "average_price": 202.8,
+            "api": true,
+            "amount": 21.0
+        }
+    }"#;
+
+    let response: ClosePositionResponse = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(response.trades.len(), 1);
+    assert!(response.order.is_some());
+
+    let trade = &response.trades[0];
+    assert_eq!(trade.trade_id, Some("ETH-2696097".to_string()));
+    assert_eq!(trade.price, Some(202.8));
+    assert_eq!(trade.direction, Some("sell".to_string()));
+    assert_eq!(trade.state, Some("filled".to_string()));
+
+    let order = response.order.as_ref().expect("order");
+    assert_eq!(order.order_id, Some("ETH-584864807".to_string()));
+    assert_eq!(order.order_state, Some("filled".to_string()));
+    assert_eq!(order.reduce_only, Some(true));
+}
+
+#[test]
+fn test_close_position_response_empty_trades() {
+    let json = r#"{
+        "trades": [],
+        "order": {
+            "order_id": "BTC-123",
+            "order_state": "open"
+        }
+    }"#;
+
+    let response: ClosePositionResponse = serde_json::from_str(json).expect("deserialize");
+    assert!(response.trades.is_empty());
+    assert!(response.order.is_some());
+}
+
+#[test]
+fn test_close_position_response_no_order() {
+    let json = r#"{
+        "trades": []
+    }"#;
+
+    let response: ClosePositionResponse = serde_json::from_str(json).expect("deserialize");
+    assert!(response.trades.is_empty());
+    assert!(response.order.is_none());
+}
+
+// CloseTrade tests
+
+#[test]
+fn test_close_trade_deserialization() {
+    let json = r#"{
+        "trade_seq": 12345,
+        "trade_id": "BTC-123456",
+        "price": 50000.0,
+        "amount": 1.0,
+        "direction": "buy"
+    }"#;
+
+    let trade: CloseTrade = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(trade.trade_seq, Some(12345));
+    assert_eq!(trade.trade_id, Some("BTC-123456".to_string()));
+    assert_eq!(trade.price, Some(50000.0));
+    assert_eq!(trade.amount, Some(1.0));
+    assert_eq!(trade.direction, Some("buy".to_string()));
+}
+
+#[test]
+fn test_close_trade_minimal() {
+    let json = r#"{}"#;
+
+    let trade: CloseTrade = serde_json::from_str(json).expect("deserialize");
+    assert!(trade.trade_seq.is_none());
+    assert!(trade.trade_id.is_none());
+    assert!(trade.price.is_none());
+}
+
+// CloseOrder tests
+
+#[test]
+fn test_close_order_deserialization() {
+    let json = r#"{
+        "order_id": "BTC-123",
+        "order_state": "open",
+        "order_type": "limit",
+        "price": 45000.0,
+        "amount": 100.0,
+        "direction": "sell"
+    }"#;
+
+    let order: CloseOrder = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(order.order_id, Some("BTC-123".to_string()));
+    assert_eq!(order.order_state, Some("open".to_string()));
+    assert_eq!(order.order_type, Some("limit".to_string()));
+    assert_eq!(order.price, Some(45000.0));
+    assert_eq!(order.amount, Some(100.0));
+    assert_eq!(order.direction, Some("sell".to_string()));
+}
+
+#[test]
+fn test_close_order_with_optional_fields() {
+    let json = r#"{
+        "order_id": "ETH-456",
+        "order_state": "filled",
+        "reduce_only": true,
+        "post_only": false,
+        "is_liquidation": false,
+        "api": true,
+        "web": false
+    }"#;
+
+    let order: CloseOrder = serde_json::from_str(json).expect("deserialize");
+    assert_eq!(order.reduce_only, Some(true));
+    assert_eq!(order.post_only, Some(false));
+    assert_eq!(order.is_liquidation, Some(false));
+    assert_eq!(order.api, Some(true));
+    assert_eq!(order.web, Some(false));
+}
+
+// Request builder tests
+
+#[test]
+fn test_request_builder_close_position_market() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_close_position_request("BTC-PERPETUAL", "market", None);
+
+    assert_eq!(request.method, "private/close_position");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["instrument_name"], "BTC-PERPETUAL");
+    assert_eq!(params["type"], "market");
+    assert!(params.get("price").is_none());
+}
+
+#[test]
+fn test_request_builder_close_position_limit() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_close_position_request("ETH-PERPETUAL", "limit", Some(3000.0));
+
+    assert_eq!(request.method, "private/close_position");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["instrument_name"], "ETH-PERPETUAL");
+    assert_eq!(params["type"], "limit");
+    assert_eq!(params["price"], 3000.0);
+}
+
+#[test]
+fn test_request_builder_move_positions() {
+    let mut builder = RequestBuilder::new();
+    let trades = vec![
+        MovePositionTrade::new("BTC-PERPETUAL", 100.0).with_price(50000.0),
+        MovePositionTrade::new("ETH-PERPETUAL", 50.0),
+    ];
+    let request = builder.build_move_positions_request("BTC", 3, 23, &trades);
+
+    assert_eq!(request.method, "private/move_positions");
+    assert!(request.params.is_some());
+
+    let params = request.params.expect("params");
+    assert_eq!(params["currency"], "BTC");
+    assert_eq!(params["source_uid"], 3);
+    assert_eq!(params["target_uid"], 23);
+
+    let trades_arr = params["trades"].as_array().expect("trades array");
+    assert_eq!(trades_arr.len(), 2);
+}
+
+#[test]
+fn test_request_builder_move_positions_single() {
+    let mut builder = RequestBuilder::new();
+    let trades = vec![MovePositionTrade::new("BTC-PERPETUAL", 110.0).with_price(35800.0)];
+    let request = builder.build_move_positions_request("BTC", 5, 10, &trades);
+
+    assert_eq!(request.method, "private/move_positions");
+    let params = request.params.expect("params");
+    assert_eq!(params["source_uid"], 5);
+    assert_eq!(params["target_uid"], 10);
+}
+
+#[test]
+fn test_request_builder_incremental_ids() {
+    let mut builder = RequestBuilder::new();
+
+    let r1 = builder.build_close_position_request("BTC-PERPETUAL", "market", None);
+    let r2 = builder.build_close_position_request("ETH-PERPETUAL", "limit", Some(3000.0));
+
+    assert_eq!(r1.id, serde_json::json!(1));
+    assert_eq!(r2.id, serde_json::json!(2));
+}


### PR DESCRIPTION
## Summary

Implement typed WebSocket methods for position management: `close_position()` to close existing positions and `move_positions()` to transfer positions between subaccounts.

## New Methods

| Method | Parameters | Return Type |
|--------|------------|-------------|
| `close_position` | `instrument: &str`, `order_type: &str`, `price: Option<f64>` | `ClosePositionResponse` |
| `move_positions` | `currency: &str`, `source_uid: u64`, `target_uid: u64`, `trades: &[MovePositionTrade]` | `Vec<MovePositionResult>` |

## New Types

- `ClosePositionResponse` - response containing order and trades
- `CloseTrade` - trade information from closing a position
- `CloseOrder` - order information from closing a position
- `MovePositionTrade` - input for move_positions (instrument, amount, optional price)
- `MovePositionResult` - result for each position moved

## Changes

| File | Change |
|------|--------|
| `src/model/position.rs` | **New** - position types |
| `src/model/mod.rs` | Export position module |
| `src/constants.rs` | Add `PRIVATE_CLOSE_POSITION`, `PRIVATE_MOVE_POSITIONS` |
| `src/message/request.rs` | Add request builders |
| `src/client.rs` | Add client methods |
| `src/prelude.rs` | Export position types |
| `tests/unit/position.rs` | **New** - 20+ unit tests |

## Testing

- [x] 201 tests pass (17 lib + 179 unit + 5 doc tests)
- [x] 20 new position tests added
- [x] `make lint-fix` passes
- [x] `make pre-push` passes

## Checklist

- [x] `close_position()` with market and limit orders
- [x] `move_positions()` with single and multiple trades
- [x] Builder pattern for `MovePositionTrade`
- [x] Comprehensive test coverage
- [x] CHANGELOG updated

Closes #8
