### PR TITLE
M2 #9: Implement public_unsubscribe_all and private_unsubscribe_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Position types: `ClosePositionResponse`, `CloseTrade`, `CloseOrder`, `MovePositionTrade`, `MovePositionResult`
 - Request builders for position management operations
 - Comprehensive unit tests for position module (25+ tests)
+- Subscription management methods: `public_unsubscribe_all()`, `private_unsubscribe_all()`
+- Request builders for unsubscribe_all operations
+- Unit tests for unsubscribe_all and SubscriptionManager.clear()
 
 ### Fixed
 - `parse_channel_type()` now correctly handles all 14 `SubscriptionChannel` variants instead of only 5

--- a/src/client.rs
+++ b/src/client.rs
@@ -152,6 +152,82 @@ impl DeribitWebSocketClient {
         self.send_request(request).await
     }
 
+    /// Unsubscribe from all public channels
+    ///
+    /// Unsubscribes from all public channels subscribed so far and clears
+    /// the local subscription manager state.
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response cannot be parsed
+    pub async fn public_unsubscribe_all(&self) -> Result<String, WebSocketError> {
+        let request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_public_unsubscribe_all_request()
+        };
+
+        let response = self.send_request(request).await?;
+
+        // Clear subscription manager
+        let mut sub_manager = self.subscription_manager.lock().await;
+        sub_manager.clear();
+
+        match response.result {
+            JsonRpcResult::Success { result } => {
+                result.as_str().map(String::from).ok_or_else(|| {
+                    WebSocketError::InvalidMessage(
+                        "Expected string result from unsubscribe_all".to_string(),
+                    )
+                })
+            }
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Unsubscribe from all private channels
+    ///
+    /// Unsubscribes from all private channels subscribed so far and clears
+    /// the local subscription manager state. Requires authentication.
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the response cannot be parsed
+    pub async fn private_unsubscribe_all(&self) -> Result<String, WebSocketError> {
+        let request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_private_unsubscribe_all_request()
+        };
+
+        let response = self.send_request(request).await?;
+
+        // Clear subscription manager
+        let mut sub_manager = self.subscription_manager.lock().await;
+        sub_manager.clear();
+
+        match response.result {
+            JsonRpcResult::Success { result } => {
+                result.as_str().map(String::from).ok_or_else(|| {
+                    WebSocketError::InvalidMessage(
+                        "Expected string result from unsubscribe_all".to_string(),
+                    )
+                })
+            }
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
     /// Send a JSON-RPC request
     pub async fn send_request(
         &self,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,10 +24,14 @@ pub mod methods {
     pub const PUBLIC_SUBSCRIBE: &str = "public/subscribe";
     /// Public unsubscription method
     pub const PUBLIC_UNSUBSCRIBE: &str = "public/unsubscribe";
+    /// Public unsubscribe from all channels
+    pub const PUBLIC_UNSUBSCRIBE_ALL: &str = "public/unsubscribe_all";
     /// Private subscription method
     pub const PRIVATE_SUBSCRIBE: &str = "private/subscribe";
     /// Private unsubscription method
     pub const PRIVATE_UNSUBSCRIBE: &str = "private/unsubscribe";
+    /// Private unsubscribe from all channels
+    pub const PRIVATE_UNSUBSCRIBE_ALL: &str = "private/unsubscribe_all";
 
     // Market data
     /// Get ticker information

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -66,6 +66,35 @@ impl RequestBuilder {
         self.build_request("public/unsubscribe", Some(params))
     }
 
+    /// Build public unsubscribe_all request
+    ///
+    /// Unsubscribes from all public channels. Takes no parameters.
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for unsubscribing from all public channels
+    pub fn build_public_unsubscribe_all_request(&mut self) -> JsonRpcRequest {
+        self.build_request(
+            crate::constants::methods::PUBLIC_UNSUBSCRIBE_ALL,
+            Some(serde_json::json!({})),
+        )
+    }
+
+    /// Build private unsubscribe_all request
+    ///
+    /// Unsubscribes from all private channels. Takes no parameters.
+    /// Requires authentication.
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for unsubscribing from all private channels
+    pub fn build_private_unsubscribe_all_request(&mut self) -> JsonRpcRequest {
+        self.build_request(
+            crate::constants::methods::PRIVATE_UNSUBSCRIBE_ALL,
+            Some(serde_json::json!({})),
+        )
+    }
+
     /// Build test request
     pub fn build_test_request(&mut self) -> JsonRpcRequest {
         self.build_request("public/test", None)

--- a/tests/unit/subscriptions.rs
+++ b/tests/unit/subscriptions.rs
@@ -160,3 +160,76 @@ fn test_subscription_manager_debug() {
 
     assert!(debug_str.contains("SubscriptionManager"));
 }
+
+#[test]
+fn test_subscription_manager_clear() {
+    let mut manager = SubscriptionManager::new();
+
+    // Add multiple subscriptions
+    manager.add_subscription(
+        "ticker.BTC-PERPETUAL".to_string(),
+        SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+        Some("BTC-PERPETUAL".to_string()),
+    );
+    manager.add_subscription(
+        "book.ETH-PERPETUAL.100ms".to_string(),
+        SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()),
+        Some("ETH-PERPETUAL".to_string()),
+    );
+    manager.add_subscription(
+        "user.orders".to_string(),
+        SubscriptionChannel::UserOrders,
+        None,
+    );
+
+    assert_eq!(manager.get_all_channels().len(), 3);
+
+    // Clear all subscriptions
+    manager.clear();
+
+    assert!(manager.get_all_channels().is_empty());
+    assert!(manager.active_subscriptions().is_empty());
+}
+
+#[test]
+fn test_subscription_manager_clear_empty() {
+    let mut manager = SubscriptionManager::new();
+
+    // Clear an already empty manager should not panic
+    manager.clear();
+
+    assert!(manager.get_all_channels().is_empty());
+}
+
+// Request builder tests for unsubscribe_all
+
+use deribit_websocket::prelude::RequestBuilder;
+
+#[test]
+fn test_request_builder_public_unsubscribe_all() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_public_unsubscribe_all_request();
+
+    assert_eq!(request.method, "public/unsubscribe_all");
+    assert!(request.params.is_some());
+}
+
+#[test]
+fn test_request_builder_private_unsubscribe_all() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_private_unsubscribe_all_request();
+
+    assert_eq!(request.method, "private/unsubscribe_all");
+    assert!(request.params.is_some());
+}
+
+#[test]
+fn test_request_builder_unsubscribe_all_incremental_ids() {
+    let mut builder = RequestBuilder::new();
+
+    let r1 = builder.build_public_unsubscribe_all_request();
+    let r2 = builder.build_private_unsubscribe_all_request();
+
+    assert_eq!(r1.id, serde_json::json!(1));
+    assert_eq!(r2.id, serde_json::json!(2));
+}


### PR DESCRIPTION
## Summary

Implement `public_unsubscribe_all()` and `private_unsubscribe_all()` methods to unsubscribe from all channels at once, clearing the local `SubscriptionManager` state.

## New Methods

| Method | API Endpoint | Return |
|--------|--------------|--------|
| `public_unsubscribe_all()` | `public/unsubscribe_all` | `"ok"` |
| `private_unsubscribe_all()` | `private/unsubscribe_all` | `"ok"` |

Both methods:
- Send the unsubscribe_all request to Deribit
- Clear the local `SubscriptionManager` state
- Return `"ok"` on success

## Changes

| File | Change |
|------|--------|
| `src/constants.rs` | Add `PUBLIC_UNSUBSCRIBE_ALL`, `PRIVATE_UNSUBSCRIBE_ALL` |
| `src/message/request.rs` | Add request builders |
| `src/client.rs` | Add client methods |
| `tests/unit/subscriptions.rs` | Add 5 unit tests |
| `CHANGELOG.md` | Document new feature |

## Testing

- [x] 206 tests pass (17 lib + 184 unit + 5 doc tests)
- [x] 5 new unsubscribe_all tests added
- [x] `make lint-fix` passes
- [x] `make pre-push` passes

## Checklist

- [x] `public_unsubscribe_all()` implemented
- [x] `private_unsubscribe_all()` implemented
- [x] `SubscriptionManager.clear()` called after unsubscribe
- [x] Request builders added
- [x] Unit tests for clear() and request builders
- [x] CHANGELOG updated

Closes #9
