### PR TITLE
feat: add block trade subscription channels

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1008,7 +1008,11 @@ impl DeribitWebSocketClient {
             | ["deribit_price_statistics", index_name]
             | ["deribit_volatility_index", index_name] => Some(index_name.to_string()),
             ["instrument", "state", _kind, currency] => Some(currency.to_string()),
-            ["platform_state"] | ["platform_state", "public_methods_state"] => None,
+            ["block_rfq", "trades", currency] => Some(currency.to_string()),
+            ["block_trade_confirmations", currency] => Some(currency.to_string()),
+            ["platform_state"]
+            | ["platform_state", "public_methods_state"]
+            | ["block_trade_confirmations"] => None,
             _ => None,
         }
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -122,4 +122,8 @@ pub mod channels {
     pub const MARKPRICE_OPTIONS: &str = "markprice.options";
     /// Quote channel
     pub const QUOTE: &str = "quote";
+    /// Block RFQ trades channel
+    pub const BLOCK_RFQ_TRADES: &str = "block_rfq.trades";
+    /// Block trade confirmations channel
+    pub const BLOCK_TRADE_CONFIRMATIONS: &str = "block_trade_confirmations";
 }

--- a/src/model/subscription.rs
+++ b/src/model/subscription.rs
@@ -72,11 +72,16 @@ impl SubscriptionManager {
             | SubscriptionChannel::Quote(inst) => Some(inst.clone()),
             SubscriptionChannel::Perpetual { instrument, .. } => Some(instrument.clone()),
             SubscriptionChannel::InstrumentState { currency, .. } => Some(currency.clone()),
+            SubscriptionChannel::BlockRfqTrades(currency)
+            | SubscriptionChannel::BlockTradeConfirmationsByCurrency(currency) => {
+                Some(currency.clone())
+            }
             SubscriptionChannel::UserOrders
             | SubscriptionChannel::UserTrades
             | SubscriptionChannel::UserPortfolio
             | SubscriptionChannel::PlatformState
             | SubscriptionChannel::PlatformStatePublicMethods
+            | SubscriptionChannel::BlockTradeConfirmations
             | SubscriptionChannel::Unknown(_) => None,
         };
         self.add_subscription(channel, channel_type, instrument);

--- a/src/model/ws_types.rs
+++ b/src/model/ws_types.rs
@@ -194,6 +194,12 @@ pub enum SubscriptionChannel {
     PriceStatistics(String),
     /// Volatility index data
     VolatilityIndex(String),
+    /// Block RFQ trades for a specific currency
+    BlockRfqTrades(String),
+    /// Block trade confirmations (all currencies)
+    BlockTradeConfirmations,
+    /// Block trade confirmations for a specific currency
+    BlockTradeConfirmationsByCurrency(String),
     /// Unknown or unrecognized channel
     Unknown(String),
 }
@@ -340,6 +346,13 @@ impl SubscriptionChannel {
             SubscriptionChannel::VolatilityIndex(index_name) => {
                 format!("deribit_volatility_index.{}", index_name)
             }
+            SubscriptionChannel::BlockRfqTrades(currency) => {
+                format!("block_rfq.trades.{}", currency)
+            }
+            SubscriptionChannel::BlockTradeConfirmations => "block_trade_confirmations".to_string(),
+            SubscriptionChannel::BlockTradeConfirmationsByCurrency(currency) => {
+                format!("block_trade_confirmations.{}", currency)
+            }
             SubscriptionChannel::Unknown(channel) => channel.clone(),
         }
     }
@@ -425,6 +438,13 @@ impl SubscriptionChannel {
             }
             ["deribit_volatility_index", index_name] => {
                 SubscriptionChannel::VolatilityIndex(index_name.to_string())
+            }
+            ["block_rfq", "trades", currency] => {
+                SubscriptionChannel::BlockRfqTrades(currency.to_string())
+            }
+            ["block_trade_confirmations"] => SubscriptionChannel::BlockTradeConfirmations,
+            ["block_trade_confirmations", currency] => {
+                SubscriptionChannel::BlockTradeConfirmationsByCurrency(currency.to_string())
             }
             _ => SubscriptionChannel::Unknown(s.to_string()),
         }

--- a/tests/unit/subscription_channel.rs
+++ b/tests/unit/subscription_channel.rs
@@ -774,3 +774,153 @@ fn test_trades_by_kind_equality() {
     assert_eq!(channel1, channel2);
     assert_ne!(channel1, channel3);
 }
+
+// =============================================================================
+// Tests for block trade subscription channels (Issue #12)
+// =============================================================================
+
+// Test block_rfq.trades channel parsing
+#[test]
+fn test_parse_channel_block_rfq_trades() {
+    let channel = SubscriptionChannel::from_string("block_rfq.trades.BTC");
+    assert!(
+        matches!(channel, SubscriptionChannel::BlockRfqTrades(ref currency) if currency == "BTC")
+    );
+}
+
+#[test]
+fn test_parse_channel_block_rfq_trades_eth() {
+    let channel = SubscriptionChannel::from_string("block_rfq.trades.ETH");
+    assert!(
+        matches!(channel, SubscriptionChannel::BlockRfqTrades(ref currency) if currency == "ETH")
+    );
+}
+
+// Test block_trade_confirmations channel parsing
+#[test]
+fn test_parse_channel_block_trade_confirmations() {
+    let channel = SubscriptionChannel::from_string("block_trade_confirmations");
+    assert!(matches!(
+        channel,
+        SubscriptionChannel::BlockTradeConfirmations
+    ));
+}
+
+#[test]
+fn test_parse_channel_block_trade_confirmations_by_currency() {
+    let channel = SubscriptionChannel::from_string("block_trade_confirmations.BTC");
+    assert!(matches!(
+        channel,
+        SubscriptionChannel::BlockTradeConfirmationsByCurrency(ref currency) if currency == "BTC"
+    ));
+}
+
+#[test]
+fn test_parse_channel_block_trade_confirmations_by_currency_eth() {
+    let channel = SubscriptionChannel::from_string("block_trade_confirmations.ETH");
+    assert!(matches!(
+        channel,
+        SubscriptionChannel::BlockTradeConfirmationsByCurrency(ref currency) if currency == "ETH"
+    ));
+}
+
+// Test channel_name for block trade channels
+#[test]
+fn test_channel_name_block_rfq_trades() {
+    let channel = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
+    assert_eq!(channel.channel_name(), "block_rfq.trades.BTC");
+}
+
+#[test]
+fn test_channel_name_block_rfq_trades_eth() {
+    let channel = SubscriptionChannel::BlockRfqTrades("ETH".to_string());
+    assert_eq!(channel.channel_name(), "block_rfq.trades.ETH");
+}
+
+#[test]
+fn test_channel_name_block_trade_confirmations() {
+    let channel = SubscriptionChannel::BlockTradeConfirmations;
+    assert_eq!(channel.channel_name(), "block_trade_confirmations");
+}
+
+#[test]
+fn test_channel_name_block_trade_confirmations_by_currency() {
+    let channel = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
+    assert_eq!(channel.channel_name(), "block_trade_confirmations.BTC");
+}
+
+#[test]
+fn test_channel_name_block_trade_confirmations_by_currency_eth() {
+    let channel = SubscriptionChannel::BlockTradeConfirmationsByCurrency("ETH".to_string());
+    assert_eq!(channel.channel_name(), "block_trade_confirmations.ETH");
+}
+
+// Test is_unknown for block trade channels
+#[test]
+fn test_is_unknown_block_rfq_trades() {
+    let channel = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
+    assert!(!channel.is_unknown());
+}
+
+#[test]
+fn test_is_unknown_block_trade_confirmations() {
+    let channel = SubscriptionChannel::BlockTradeConfirmations;
+    assert!(!channel.is_unknown());
+}
+
+#[test]
+fn test_is_unknown_block_trade_confirmations_by_currency() {
+    let channel = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
+    assert!(!channel.is_unknown());
+}
+
+// Test equality for block trade channels
+#[test]
+fn test_block_rfq_trades_equality() {
+    let channel1 = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
+    let channel2 = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
+    let channel3 = SubscriptionChannel::BlockRfqTrades("ETH".to_string());
+    assert_eq!(channel1, channel2);
+    assert_ne!(channel1, channel3);
+}
+
+#[test]
+fn test_block_trade_confirmations_equality() {
+    let channel1 = SubscriptionChannel::BlockTradeConfirmations;
+    let channel2 = SubscriptionChannel::BlockTradeConfirmations;
+    assert_eq!(channel1, channel2);
+}
+
+#[test]
+fn test_block_trade_confirmations_by_currency_equality() {
+    let channel1 = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
+    let channel2 = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
+    let channel3 = SubscriptionChannel::BlockTradeConfirmationsByCurrency("ETH".to_string());
+    assert_eq!(channel1, channel2);
+    assert_ne!(channel1, channel3);
+}
+
+// Test roundtrip for block trade channels
+#[test]
+fn test_block_rfq_trades_roundtrip() {
+    let original = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
+    let channel_name = original.channel_name();
+    let parsed = SubscriptionChannel::from_string(&channel_name);
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_block_trade_confirmations_roundtrip() {
+    let original = SubscriptionChannel::BlockTradeConfirmations;
+    let channel_name = original.channel_name();
+    let parsed = SubscriptionChannel::from_string(&channel_name);
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_block_trade_confirmations_by_currency_roundtrip() {
+    let original = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
+    let channel_name = original.channel_name();
+    let parsed = SubscriptionChannel::from_string(&channel_name);
+    assert_eq!(original, parsed);
+}


### PR DESCRIPTION
## Summary

Add support for block trade related subscription channel types as specified in issue #12.

## Changes

### New Subscription Channel Variants
- **BlockRfqTrades(String)**: `block_rfq.trades.{currency}` channel for block RFQ trades
- **BlockTradeConfirmations**: `block_trade_confirmations` channel (all currencies)
- **BlockTradeConfirmationsByCurrency(String)**: `block_trade_confirmations.{currency}` channel

### Files Modified
- `src/model/ws_types.rs`: Added new enum variants, updated `channel_name()` and `from_string()`
- `src/constants.rs`: Added channel constants
- `src/model/subscription.rs`: Updated `add_subscription_from_channel()`
- `src/client.rs`: Updated `extract_instrument()`
- `tests/unit/subscription_channel.rs`: Added 19 unit tests

## Testing

- All 265 unit tests pass
- `make lint-fix` ✓
- `make pre-push` ✓

Closes #12