### PR TITLE
feat: add private subscription channels

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1010,9 +1010,12 @@ impl DeribitWebSocketClient {
             ["instrument", "state", _kind, currency] => Some(currency.to_string()),
             ["block_rfq", "trades", currency] => Some(currency.to_string()),
             ["block_trade_confirmations", currency] => Some(currency.to_string()),
+            ["user", "mmp_trigger", index_name] => Some(index_name.to_string()),
             ["platform_state"]
             | ["platform_state", "public_methods_state"]
-            | ["block_trade_confirmations"] => None,
+            | ["block_trade_confirmations"]
+            | ["user", "access_log"]
+            | ["user", "lock"] => None,
             _ => None,
         }
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -126,4 +126,10 @@ pub mod channels {
     pub const BLOCK_RFQ_TRADES: &str = "block_rfq.trades";
     /// Block trade confirmations channel
     pub const BLOCK_TRADE_CONFIRMATIONS: &str = "block_trade_confirmations";
+    /// User MMP trigger channel
+    pub const USER_MMP_TRIGGER: &str = "user.mmp_trigger";
+    /// User access log channel
+    pub const USER_ACCESS_LOG: &str = "user.access_log";
+    /// User lock channel
+    pub const USER_LOCK: &str = "user.lock";
 }

--- a/src/model/subscription.rs
+++ b/src/model/subscription.rs
@@ -76,12 +76,15 @@ impl SubscriptionManager {
             | SubscriptionChannel::BlockTradeConfirmationsByCurrency(currency) => {
                 Some(currency.clone())
             }
+            SubscriptionChannel::UserMmpTrigger(index_name) => Some(index_name.clone()),
             SubscriptionChannel::UserOrders
             | SubscriptionChannel::UserTrades
             | SubscriptionChannel::UserPortfolio
             | SubscriptionChannel::PlatformState
             | SubscriptionChannel::PlatformStatePublicMethods
             | SubscriptionChannel::BlockTradeConfirmations
+            | SubscriptionChannel::UserAccessLog
+            | SubscriptionChannel::UserLock
             | SubscriptionChannel::Unknown(_) => None,
         };
         self.add_subscription(channel, channel_type, instrument);

--- a/src/model/ws_types.rs
+++ b/src/model/ws_types.rs
@@ -200,6 +200,12 @@ pub enum SubscriptionChannel {
     BlockTradeConfirmations,
     /// Block trade confirmations for a specific currency
     BlockTradeConfirmationsByCurrency(String),
+    /// User MMP (Market Maker Protection) trigger for a specific index
+    UserMmpTrigger(String),
+    /// User API access log
+    UserAccessLog,
+    /// User account lock status
+    UserLock,
     /// Unknown or unrecognized channel
     Unknown(String),
 }
@@ -353,6 +359,11 @@ impl SubscriptionChannel {
             SubscriptionChannel::BlockTradeConfirmationsByCurrency(currency) => {
                 format!("block_trade_confirmations.{}", currency)
             }
+            SubscriptionChannel::UserMmpTrigger(index_name) => {
+                format!("user.mmp_trigger.{}", index_name)
+            }
+            SubscriptionChannel::UserAccessLog => "user.access_log".to_string(),
+            SubscriptionChannel::UserLock => "user.lock".to_string(),
             SubscriptionChannel::Unknown(channel) => channel.clone(),
         }
     }
@@ -446,6 +457,11 @@ impl SubscriptionChannel {
             ["block_trade_confirmations", currency] => {
                 SubscriptionChannel::BlockTradeConfirmationsByCurrency(currency.to_string())
             }
+            ["user", "mmp_trigger", index_name] => {
+                SubscriptionChannel::UserMmpTrigger(index_name.to_string())
+            }
+            ["user", "access_log"] => SubscriptionChannel::UserAccessLog,
+            ["user", "lock"] => SubscriptionChannel::UserLock,
             _ => SubscriptionChannel::Unknown(s.to_string()),
         }
     }

--- a/tests/unit/subscription_channel.rs
+++ b/tests/unit/subscription_channel.rs
@@ -924,3 +924,131 @@ fn test_block_trade_confirmations_by_currency_roundtrip() {
     let parsed = SubscriptionChannel::from_string(&channel_name);
     assert_eq!(original, parsed);
 }
+
+// =============================================================================
+// Tests for private subscription channels (Issue #13)
+// =============================================================================
+
+// Test user.mmp_trigger channel parsing
+#[test]
+fn test_parse_channel_user_mmp_trigger() {
+    let channel = SubscriptionChannel::from_string("user.mmp_trigger.btc_usd");
+    assert!(
+        matches!(channel, SubscriptionChannel::UserMmpTrigger(ref index) if index == "btc_usd")
+    );
+}
+
+#[test]
+fn test_parse_channel_user_mmp_trigger_eth() {
+    let channel = SubscriptionChannel::from_string("user.mmp_trigger.eth_usd");
+    assert!(
+        matches!(channel, SubscriptionChannel::UserMmpTrigger(ref index) if index == "eth_usd")
+    );
+}
+
+// Test user.access_log channel parsing
+#[test]
+fn test_parse_channel_user_access_log() {
+    let channel = SubscriptionChannel::from_string("user.access_log");
+    assert!(matches!(channel, SubscriptionChannel::UserAccessLog));
+}
+
+// Test user.lock channel parsing
+#[test]
+fn test_parse_channel_user_lock() {
+    let channel = SubscriptionChannel::from_string("user.lock");
+    assert!(matches!(channel, SubscriptionChannel::UserLock));
+}
+
+// Test channel_name for private channels
+#[test]
+fn test_channel_name_user_mmp_trigger() {
+    let channel = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
+    assert_eq!(channel.channel_name(), "user.mmp_trigger.btc_usd");
+}
+
+#[test]
+fn test_channel_name_user_mmp_trigger_eth() {
+    let channel = SubscriptionChannel::UserMmpTrigger("eth_usd".to_string());
+    assert_eq!(channel.channel_name(), "user.mmp_trigger.eth_usd");
+}
+
+#[test]
+fn test_channel_name_user_access_log() {
+    let channel = SubscriptionChannel::UserAccessLog;
+    assert_eq!(channel.channel_name(), "user.access_log");
+}
+
+#[test]
+fn test_channel_name_user_lock() {
+    let channel = SubscriptionChannel::UserLock;
+    assert_eq!(channel.channel_name(), "user.lock");
+}
+
+// Test is_unknown for private channels
+#[test]
+fn test_is_unknown_user_mmp_trigger() {
+    let channel = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
+    assert!(!channel.is_unknown());
+}
+
+#[test]
+fn test_is_unknown_user_access_log() {
+    let channel = SubscriptionChannel::UserAccessLog;
+    assert!(!channel.is_unknown());
+}
+
+#[test]
+fn test_is_unknown_user_lock() {
+    let channel = SubscriptionChannel::UserLock;
+    assert!(!channel.is_unknown());
+}
+
+// Test equality for private channels
+#[test]
+fn test_user_mmp_trigger_equality() {
+    let channel1 = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
+    let channel2 = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
+    let channel3 = SubscriptionChannel::UserMmpTrigger("eth_usd".to_string());
+    assert_eq!(channel1, channel2);
+    assert_ne!(channel1, channel3);
+}
+
+#[test]
+fn test_user_access_log_equality() {
+    let channel1 = SubscriptionChannel::UserAccessLog;
+    let channel2 = SubscriptionChannel::UserAccessLog;
+    assert_eq!(channel1, channel2);
+}
+
+#[test]
+fn test_user_lock_equality() {
+    let channel1 = SubscriptionChannel::UserLock;
+    let channel2 = SubscriptionChannel::UserLock;
+    assert_eq!(channel1, channel2);
+}
+
+// Test roundtrip for private channels
+#[test]
+fn test_user_mmp_trigger_roundtrip() {
+    let original = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
+    let channel_name = original.channel_name();
+    let parsed = SubscriptionChannel::from_string(&channel_name);
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_user_access_log_roundtrip() {
+    let original = SubscriptionChannel::UserAccessLog;
+    let channel_name = original.channel_name();
+    let parsed = SubscriptionChannel::from_string(&channel_name);
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_user_lock_roundtrip() {
+    let original = SubscriptionChannel::UserLock;
+    let channel_name = original.channel_name();
+    let parsed = SubscriptionChannel::from_string(&channel_name);
+    assert_eq!(original, parsed);
+}


### PR DESCRIPTION
## Summary

Add support for missing private subscription channel types as specified in issue #13.

## Changes

### New Subscription Channel Variants
- **UserMmpTrigger(String)**: `user.mmp_trigger.{index_name}` channel for Market Maker Protection triggers
- **UserAccessLog**: `user.access_log` channel for API access logging
- **UserLock**: `user.lock` channel for account lock status

### Files Modified
- `src/model/ws_types.rs`: Added new enum variants, updated `channel_name()` and `from_string()`
- `src/constants.rs`: Added channel constants
- `src/model/subscription.rs`: Updated `add_subscription_from_channel()`
- `src/client.rs`: Updated `extract_instrument()`
- `tests/unit/subscription_channel.rs`: Added 17 unit tests

## Testing

- All 282 unit tests pass
- `make lint-fix` ✓
- `make pre-push` ✓

Closes #13