### PR TITLE
feat: implement cancel-on-disconnect methods

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -409,6 +409,113 @@ impl DeribitWebSocketClient {
         self.send_request(request).await
     }
 
+    /// Enable automatic order cancellation on disconnect
+    ///
+    /// When enabled, all open orders will be automatically cancelled if the WebSocket
+    /// connection is lost. This is a safety feature to prevent unintended order
+    /// execution when the client loses connectivity.
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or requires authentication
+    pub async fn enable_cancel_on_disconnect(&self) -> Result<String, WebSocketError> {
+        let request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_enable_cancel_on_disconnect_request()
+        };
+
+        let response = self.send_request(request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => {
+                result.as_str().map(String::from).ok_or_else(|| {
+                    WebSocketError::InvalidMessage(
+                        "Expected string result from enable_cancel_on_disconnect".to_string(),
+                    )
+                })
+            }
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Disable automatic order cancellation on disconnect
+    ///
+    /// When disabled, orders will remain active even if the WebSocket connection
+    /// is lost.
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or requires authentication
+    pub async fn disable_cancel_on_disconnect(&self) -> Result<String, WebSocketError> {
+        let request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_disable_cancel_on_disconnect_request()
+        };
+
+        let response = self.send_request(request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => {
+                result.as_str().map(String::from).ok_or_else(|| {
+                    WebSocketError::InvalidMessage(
+                        "Expected string result from disable_cancel_on_disconnect".to_string(),
+                    )
+                })
+            }
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
+    /// Get current cancel-on-disconnect status
+    ///
+    /// Returns whether automatic order cancellation on disconnect is currently enabled.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if cancel-on-disconnect is enabled, `false` otherwise
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or requires authentication
+    pub async fn get_cancel_on_disconnect(&self) -> Result<bool, WebSocketError> {
+        let request = {
+            let mut builder = self.request_builder.lock().await;
+            builder.build_get_cancel_on_disconnect_request()
+        };
+
+        let response = self.send_request(request).await?;
+
+        match response.result {
+            JsonRpcResult::Success { result } => {
+                // The result contains "enabled" field
+                result
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .ok_or_else(|| {
+                        WebSocketError::InvalidMessage(
+                            "Expected 'enabled' boolean in get_cancel_on_disconnect response"
+                                .to_string(),
+                        )
+                    })
+            }
+            JsonRpcResult::Error { error } => {
+                Err(WebSocketError::ApiError(error.code, error.message))
+            }
+        }
+    }
+
     /// Place mass quotes
     pub async fn mass_quote(
         &self,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -85,6 +85,14 @@ pub mod methods {
     /// Move positions between subaccounts
     pub const PRIVATE_MOVE_POSITIONS: &str = "private/move_positions";
 
+    // Cancel-on-disconnect
+    /// Enable cancel-on-disconnect
+    pub const PRIVATE_ENABLE_CANCEL_ON_DISCONNECT: &str = "private/enable_cancel_on_disconnect";
+    /// Disable cancel-on-disconnect
+    pub const PRIVATE_DISABLE_CANCEL_ON_DISCONNECT: &str = "private/disable_cancel_on_disconnect";
+    /// Get cancel-on-disconnect status
+    pub const PRIVATE_GET_CANCEL_ON_DISCONNECT: &str = "private/get_cancel_on_disconnect";
+
     // Test
     /// Test connection
     pub const PUBLIC_TEST: &str = "public/test";

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -167,6 +167,51 @@ impl RequestBuilder {
         self.build_request("public/get_time", None)
     }
 
+    /// Build enable_cancel_on_disconnect request
+    ///
+    /// Enables automatic cancellation of all open orders when the WebSocket connection
+    /// is lost. This is a safety feature to prevent unintended order execution when
+    /// the client loses connectivity.
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for enabling cancel-on-disconnect
+    pub fn build_enable_cancel_on_disconnect_request(&mut self) -> JsonRpcRequest {
+        self.build_request(
+            crate::constants::methods::PRIVATE_ENABLE_CANCEL_ON_DISCONNECT,
+            Some(serde_json::json!({})),
+        )
+    }
+
+    /// Build disable_cancel_on_disconnect request
+    ///
+    /// Disables automatic cancellation of orders on disconnect. Orders will remain
+    /// active even if the WebSocket connection is lost.
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for disabling cancel-on-disconnect
+    pub fn build_disable_cancel_on_disconnect_request(&mut self) -> JsonRpcRequest {
+        self.build_request(
+            crate::constants::methods::PRIVATE_DISABLE_CANCEL_ON_DISCONNECT,
+            Some(serde_json::json!({})),
+        )
+    }
+
+    /// Build get_cancel_on_disconnect request
+    ///
+    /// Retrieves the current cancel-on-disconnect status for the session.
+    ///
+    /// # Returns
+    ///
+    /// A JSON-RPC request for getting the cancel-on-disconnect status
+    pub fn build_get_cancel_on_disconnect_request(&mut self) -> JsonRpcRequest {
+        self.build_request(
+            crate::constants::methods::PRIVATE_GET_CANCEL_ON_DISCONNECT,
+            Some(serde_json::json!({})),
+        )
+    }
+
     /// Build mass quote request
     pub fn build_mass_quote_request(&mut self, request: MassQuoteRequest) -> JsonRpcRequest {
         let params = serde_json::to_value(request).expect("Failed to serialize mass quote request");

--- a/tests/unit/message.rs
+++ b/tests/unit/message.rs
@@ -269,3 +269,95 @@ fn test_request_builder_incremental_ids_session_methods() {
     assert_eq!(id2, id1 + 1);
     assert_eq!(id3, id2 + 1);
 }
+
+// =============================================================================
+// Cancel-on-disconnect request tests (Issue #15)
+// =============================================================================
+
+#[test]
+fn test_request_builder_enable_cancel_on_disconnect() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_enable_cancel_on_disconnect_request();
+
+    assert_eq!(request.method, "private/enable_cancel_on_disconnect");
+    assert_eq!(request.jsonrpc, "2.0");
+    assert!(request.id.is_number());
+    assert!(request.params.is_some());
+}
+
+#[test]
+fn test_request_builder_disable_cancel_on_disconnect() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_disable_cancel_on_disconnect_request();
+
+    assert_eq!(request.method, "private/disable_cancel_on_disconnect");
+    assert_eq!(request.jsonrpc, "2.0");
+    assert!(request.id.is_number());
+    assert!(request.params.is_some());
+}
+
+#[test]
+fn test_request_builder_get_cancel_on_disconnect() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_get_cancel_on_disconnect_request();
+
+    assert_eq!(request.method, "private/get_cancel_on_disconnect");
+    assert_eq!(request.jsonrpc, "2.0");
+    assert!(request.id.is_number());
+    assert!(request.params.is_some());
+}
+
+#[test]
+fn test_request_builder_enable_cancel_on_disconnect_serialization() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_enable_cancel_on_disconnect_request();
+
+    let serialized = serde_json::to_string(&request).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(parsed["jsonrpc"], "2.0");
+    assert_eq!(parsed["method"], "private/enable_cancel_on_disconnect");
+    assert!(parsed["id"].is_number());
+}
+
+#[test]
+fn test_request_builder_disable_cancel_on_disconnect_serialization() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_disable_cancel_on_disconnect_request();
+
+    let serialized = serde_json::to_string(&request).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(parsed["jsonrpc"], "2.0");
+    assert_eq!(parsed["method"], "private/disable_cancel_on_disconnect");
+    assert!(parsed["id"].is_number());
+}
+
+#[test]
+fn test_request_builder_get_cancel_on_disconnect_serialization() {
+    let mut builder = RequestBuilder::new();
+    let request = builder.build_get_cancel_on_disconnect_request();
+
+    let serialized = serde_json::to_string(&request).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(parsed["jsonrpc"], "2.0");
+    assert_eq!(parsed["method"], "private/get_cancel_on_disconnect");
+    assert!(parsed["id"].is_number());
+}
+
+#[test]
+fn test_request_builder_incremental_ids_cancel_on_disconnect() {
+    let mut builder = RequestBuilder::new();
+
+    let req1 = builder.build_enable_cancel_on_disconnect_request();
+    let req2 = builder.build_disable_cancel_on_disconnect_request();
+    let req3 = builder.build_get_cancel_on_disconnect_request();
+
+    let id1 = req1.id.as_u64().unwrap();
+    let id2 = req2.id.as_u64().unwrap();
+    let id3 = req3.id.as_u64().unwrap();
+
+    assert_eq!(id2, id1 + 1);
+    assert_eq!(id3, id2 + 1);
+}


### PR DESCRIPTION
## Summary

Implement cancel-on-disconnect session management methods as specified in issue #15.

## Changes

### New Methods on `DeribitWebSocketClient`
- **enable_cancel_on_disconnect()**: Enable automatic order cancellation when the WebSocket connection is lost
- **disable_cancel_on_disconnect()**: Disable automatic order cancellation on disconnect
- **get_cancel_on_disconnect()**: Get current cancel-on-disconnect status (returns bool)

### Files Modified
- `src/constants.rs`: Added `PRIVATE_ENABLE_CANCEL_ON_DISCONNECT`, `PRIVATE_DISABLE_CANCEL_ON_DISCONNECT`, `PRIVATE_GET_CANCEL_ON_DISCONNECT` constants
- `src/message/request.rs`: Added request builder methods with documentation
- `src/client.rs`: Implemented client methods with proper error handling
- `tests/unit/message.rs`: Added 7 unit tests for request builders

## API Methods

| Method | Deribit API | Description |
|--------|-------------|-------------|
| `enable_cancel_on_disconnect()` | `private/enable_cancel_on_disconnect` | Enable auto-cancellation |
| `disable_cancel_on_disconnect()` | `private/disable_cancel_on_disconnect` | Disable auto-cancellation |
| `get_cancel_on_disconnect()` | `private/get_cancel_on_disconnect` | Get status |

## Testing

- All 297 unit tests pass
- `make lint-fix` ✓
- `make pre-push` ✓

Closes #15