### PR TITLE
feat: v0.2.0 examples and improved test coverage

### DIFF
--- a/tests/unit/builder.rs
+++ b/tests/unit/builder.rs
@@ -1,0 +1,123 @@
+//! Unit tests for message/builder.rs
+
+use deribit_websocket::message::{MessageBuilder, MessageType};
+
+#[test]
+fn test_message_builder_new() {
+    let builder = MessageBuilder::new();
+    // Verify builder is created successfully
+    assert!(format!("{:?}", builder).contains("MessageBuilder"));
+}
+
+#[test]
+fn test_message_builder_default() {
+    let builder = MessageBuilder::default();
+    assert!(format!("{:?}", builder).contains("MessageBuilder"));
+}
+
+#[test]
+fn test_message_builder_request_builder() {
+    let mut builder = MessageBuilder::new();
+    let request_builder = builder.request_builder();
+    // Verify we can access the request builder
+    assert!(format!("{:?}", request_builder).contains("RequestBuilder"));
+}
+
+#[test]
+fn test_message_builder_response_handler() {
+    let builder = MessageBuilder::new();
+    let response_handler = builder.response_handler();
+    assert!(format!("{:?}", response_handler).contains("ResponseHandler"));
+}
+
+#[test]
+fn test_message_builder_notification_handler() {
+    let builder = MessageBuilder::new();
+    let notification_handler = builder.notification_handler();
+    assert!(format!("{:?}", notification_handler).contains("NotificationHandler"));
+}
+
+#[test]
+fn test_parse_message_response() {
+    let builder = MessageBuilder::new();
+    
+    let response_json = r#"{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"version": "1.2.26"}
+    }"#;
+    
+    let result = builder.parse_message(response_json);
+    assert!(result.is_ok());
+    
+    if let Ok(MessageType::Response(response)) = result {
+        assert_eq!(response.id.as_u64().unwrap(), 1);
+    } else {
+        panic!("Expected Response message type");
+    }
+}
+
+#[test]
+fn test_parse_message_notification() {
+    let builder = MessageBuilder::new();
+    
+    let notification_json = r#"{
+        "jsonrpc": "2.0",
+        "method": "subscription",
+        "params": {
+            "channel": "ticker.BTC-PERPETUAL",
+            "data": {"price": 50000}
+        }
+    }"#;
+    
+    let result = builder.parse_message(notification_json);
+    assert!(result.is_ok());
+    
+    if let Ok(MessageType::Notification(notification)) = result {
+        assert_eq!(notification.method, "subscription");
+    } else {
+        panic!("Expected Notification message type");
+    }
+}
+
+#[test]
+fn test_parse_message_invalid() {
+    let builder = MessageBuilder::new();
+    
+    let invalid_json = r#"not valid json"#;
+    
+    let result = builder.parse_message(invalid_json);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_message_type_debug() {
+    let builder = MessageBuilder::new();
+    
+    let response_json = r#"{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"version": "1.2.26"}
+    }"#;
+    
+    if let Ok(msg_type) = builder.parse_message(response_json) {
+        let debug_str = format!("{:?}", msg_type);
+        assert!(debug_str.contains("Response"));
+    }
+}
+
+#[test]
+fn test_message_type_clone() {
+    let builder = MessageBuilder::new();
+    
+    let response_json = r#"{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"version": "1.2.26"}
+    }"#;
+    
+    if let Ok(msg_type) = builder.parse_message(response_json) {
+        let cloned = msg_type.clone();
+        assert!(format!("{:?}", cloned).contains("Response"));
+    }
+}

--- a/tests/unit/builder.rs
+++ b/tests/unit/builder.rs
@@ -40,16 +40,16 @@ fn test_message_builder_notification_handler() {
 #[test]
 fn test_parse_message_response() {
     let builder = MessageBuilder::new();
-    
+
     let response_json = r#"{
         "jsonrpc": "2.0",
         "id": 1,
         "result": {"version": "1.2.26"}
     }"#;
-    
+
     let result = builder.parse_message(response_json);
     assert!(result.is_ok());
-    
+
     if let Ok(MessageType::Response(response)) = result {
         assert_eq!(response.id.as_u64().unwrap(), 1);
     } else {
@@ -60,7 +60,7 @@ fn test_parse_message_response() {
 #[test]
 fn test_parse_message_notification() {
     let builder = MessageBuilder::new();
-    
+
     let notification_json = r#"{
         "jsonrpc": "2.0",
         "method": "subscription",
@@ -69,10 +69,10 @@ fn test_parse_message_notification() {
             "data": {"price": 50000}
         }
     }"#;
-    
+
     let result = builder.parse_message(notification_json);
     assert!(result.is_ok());
-    
+
     if let Ok(MessageType::Notification(notification)) = result {
         assert_eq!(notification.method, "subscription");
     } else {
@@ -83,9 +83,9 @@ fn test_parse_message_notification() {
 #[test]
 fn test_parse_message_invalid() {
     let builder = MessageBuilder::new();
-    
+
     let invalid_json = r#"not valid json"#;
-    
+
     let result = builder.parse_message(invalid_json);
     assert!(result.is_err());
 }
@@ -93,13 +93,13 @@ fn test_parse_message_invalid() {
 #[test]
 fn test_message_type_debug() {
     let builder = MessageBuilder::new();
-    
+
     let response_json = r#"{
         "jsonrpc": "2.0",
         "id": 1,
         "result": {"version": "1.2.26"}
     }"#;
-    
+
     if let Ok(msg_type) = builder.parse_message(response_json) {
         let debug_str = format!("{:?}", msg_type);
         assert!(debug_str.contains("Response"));
@@ -109,13 +109,13 @@ fn test_message_type_debug() {
 #[test]
 fn test_message_type_clone() {
     let builder = MessageBuilder::new();
-    
+
     let response_json = r#"{
         "jsonrpc": "2.0",
         "id": 1,
         "result": {"version": "1.2.26"}
     }"#;
-    
+
     if let Ok(msg_type) = builder.parse_message(response_json) {
         let cloned = msg_type.clone();
         assert!(format!("{:?}", cloned).contains("Response"));

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -88,3 +88,89 @@ fn test_config_debug() {
     assert!(debug_str.contains("ws_url"));
     assert!(debug_str.contains("heartbeat_interval"));
 }
+
+#[test]
+fn test_config_with_connection_timeout() {
+    let config = WebSocketConfig::default()
+        .with_connection_timeout(Duration::from_secs(120));
+
+    assert_eq!(config.connection_timeout, Duration::from_secs(120));
+}
+
+#[test]
+fn test_config_with_credentials() {
+    let config = WebSocketConfig::default()
+        .with_credentials("client_id".to_string(), "client_secret".to_string());
+
+    assert_eq!(config.client_id, Some("client_id".to_string()));
+    assert_eq!(config.client_secret, Some("client_secret".to_string()));
+}
+
+#[test]
+fn test_config_with_client_id() {
+    let config = WebSocketConfig::default()
+        .with_client_id("my_client_id".to_string());
+
+    assert_eq!(config.client_id, Some("my_client_id".to_string()));
+}
+
+#[test]
+fn test_config_with_client_secret() {
+    let config = WebSocketConfig::default()
+        .with_client_secret("my_secret".to_string());
+
+    assert_eq!(config.client_secret, Some("my_secret".to_string()));
+}
+
+#[test]
+fn test_config_with_logging() {
+    let config = WebSocketConfig::default()
+        .with_logging(true);
+
+    assert!(config.enable_logging);
+}
+
+#[test]
+fn test_config_with_logging_disabled() {
+    let config = WebSocketConfig::default()
+        .with_logging(false);
+
+    assert!(!config.enable_logging);
+}
+
+#[test]
+fn test_config_with_log_level() {
+    let config = WebSocketConfig::default()
+        .with_log_level("debug".to_string());
+
+    assert_eq!(config.log_level, "debug");
+}
+
+#[test]
+fn test_config_with_test_mode() {
+    let config = WebSocketConfig::default()
+        .with_test_mode(true);
+
+    assert!(config.test_mode);
+}
+
+#[test]
+fn test_config_has_credentials_true() {
+    let config = WebSocketConfig::default()
+        .with_credentials("client_id".to_string(), "client_secret".to_string());
+
+    assert!(config.has_credentials());
+}
+
+#[test]
+fn test_config_get_credentials_some() {
+    let config = WebSocketConfig::default()
+        .with_credentials("client_id".to_string(), "client_secret".to_string());
+
+    let creds = config.get_credentials();
+    assert!(creds.is_some());
+
+    let (id, secret) = creds.unwrap();
+    assert_eq!(id, "client_id");
+    assert_eq!(secret, "client_secret");
+}

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -91,8 +91,7 @@ fn test_config_debug() {
 
 #[test]
 fn test_config_with_connection_timeout() {
-    let config = WebSocketConfig::default()
-        .with_connection_timeout(Duration::from_secs(120));
+    let config = WebSocketConfig::default().with_connection_timeout(Duration::from_secs(120));
 
     assert_eq!(config.connection_timeout, Duration::from_secs(120));
 }
@@ -108,48 +107,42 @@ fn test_config_with_credentials() {
 
 #[test]
 fn test_config_with_client_id() {
-    let config = WebSocketConfig::default()
-        .with_client_id("my_client_id".to_string());
+    let config = WebSocketConfig::default().with_client_id("my_client_id".to_string());
 
     assert_eq!(config.client_id, Some("my_client_id".to_string()));
 }
 
 #[test]
 fn test_config_with_client_secret() {
-    let config = WebSocketConfig::default()
-        .with_client_secret("my_secret".to_string());
+    let config = WebSocketConfig::default().with_client_secret("my_secret".to_string());
 
     assert_eq!(config.client_secret, Some("my_secret".to_string()));
 }
 
 #[test]
 fn test_config_with_logging() {
-    let config = WebSocketConfig::default()
-        .with_logging(true);
+    let config = WebSocketConfig::default().with_logging(true);
 
     assert!(config.enable_logging);
 }
 
 #[test]
 fn test_config_with_logging_disabled() {
-    let config = WebSocketConfig::default()
-        .with_logging(false);
+    let config = WebSocketConfig::default().with_logging(false);
 
     assert!(!config.enable_logging);
 }
 
 #[test]
 fn test_config_with_log_level() {
-    let config = WebSocketConfig::default()
-        .with_log_level("debug".to_string());
+    let config = WebSocketConfig::default().with_log_level("debug".to_string());
 
     assert_eq!(config.log_level, "debug");
 }
 
 #[test]
 fn test_config_with_test_mode() {
-    let config = WebSocketConfig::default()
-        .with_test_mode(true);
+    let config = WebSocketConfig::default().with_test_mode(true);
 
     assert!(config.test_mode);
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -4,6 +4,7 @@
 //! Each submodule tests a specific component of the WebSocket client.
 
 pub mod account;
+pub mod builder;
 pub mod callback;
 pub mod client;
 pub mod config;
@@ -11,8 +12,11 @@ pub mod connection;
 pub mod error;
 pub mod message;
 pub mod model;
+pub mod notification;
 pub mod position;
+pub mod response;
 pub mod session;
 pub mod subscription_channel;
 pub mod subscriptions;
+pub mod subscriptions_legacy;
 pub mod trading;

--- a/tests/unit/notification.rs
+++ b/tests/unit/notification.rs
@@ -1,0 +1,176 @@
+//! Unit tests for message/notification.rs
+
+use deribit_websocket::message::NotificationHandler;
+use deribit_websocket::model::ws_types::JsonRpcNotification;
+
+#[test]
+fn test_notification_handler_new() {
+    let handler = NotificationHandler::new();
+    assert!(format!("{:?}", handler).contains("NotificationHandler"));
+}
+
+#[test]
+fn test_notification_handler_default() {
+    let handler = NotificationHandler::default();
+    assert!(format!("{:?}", handler).contains("NotificationHandler"));
+}
+
+#[test]
+fn test_notification_handler_clone() {
+    let handler = NotificationHandler::new();
+    let cloned = handler.clone();
+    assert!(format!("{:?}", cloned).contains("NotificationHandler"));
+}
+
+#[test]
+fn test_parse_notification_valid() {
+    let handler = NotificationHandler::new();
+    
+    let json = r#"{
+        "jsonrpc": "2.0",
+        "method": "subscription",
+        "params": {
+            "channel": "ticker.BTC-PERPETUAL",
+            "data": {"price": 50000}
+        }
+    }"#;
+    
+    let result = handler.parse_notification(json);
+    assert!(result.is_ok());
+    
+    let notification = result.unwrap();
+    assert_eq!(notification.method, "subscription");
+}
+
+#[test]
+fn test_parse_notification_invalid() {
+    let handler = NotificationHandler::new();
+    
+    let json = r#"not valid json"#;
+    
+    let result = handler.parse_notification(json);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_is_subscription_notification_true() {
+    let handler = NotificationHandler::new();
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: None,
+    };
+    
+    assert!(handler.is_subscription_notification(&notification));
+}
+
+#[test]
+fn test_is_subscription_notification_false() {
+    let handler = NotificationHandler::new();
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "heartbeat".to_string(),
+        params: None,
+    };
+    
+    assert!(!handler.is_subscription_notification(&notification));
+}
+
+#[test]
+fn test_extract_channel_with_channel() {
+    let handler = NotificationHandler::new();
+    
+    let mut params = serde_json::Map::new();
+    params.insert("channel".to_string(), serde_json::json!("ticker.BTC-PERPETUAL"));
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: Some(serde_json::Value::Object(params)),
+    };
+    
+    let channel = handler.extract_channel(&notification);
+    assert_eq!(channel, Some("ticker.BTC-PERPETUAL".to_string()));
+}
+
+#[test]
+fn test_extract_channel_no_params() {
+    let handler = NotificationHandler::new();
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: None,
+    };
+    
+    let channel = handler.extract_channel(&notification);
+    assert!(channel.is_none());
+}
+
+#[test]
+fn test_extract_channel_no_channel_field() {
+    let handler = NotificationHandler::new();
+    
+    let mut params = serde_json::Map::new();
+    params.insert("data".to_string(), serde_json::json!({"price": 50000}));
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: Some(serde_json::Value::Object(params)),
+    };
+    
+    let channel = handler.extract_channel(&notification);
+    assert!(channel.is_none());
+}
+
+#[test]
+fn test_extract_data_with_data() {
+    let handler = NotificationHandler::new();
+    
+    let mut params = serde_json::Map::new();
+    params.insert("data".to_string(), serde_json::json!({"price": 50000}));
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: Some(serde_json::Value::Object(params)),
+    };
+    
+    let data = handler.extract_data(&notification);
+    assert!(data.is_some());
+    assert_eq!(data.unwrap()["price"], 50000);
+}
+
+#[test]
+fn test_extract_data_no_params() {
+    let handler = NotificationHandler::new();
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: None,
+    };
+    
+    let data = handler.extract_data(&notification);
+    assert!(data.is_none());
+}
+
+#[test]
+fn test_extract_data_no_data_field() {
+    let handler = NotificationHandler::new();
+    
+    let mut params = serde_json::Map::new();
+    params.insert("channel".to_string(), serde_json::json!("ticker.BTC-PERPETUAL"));
+    
+    let notification = JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "subscription".to_string(),
+        params: Some(serde_json::Value::Object(params)),
+    };
+    
+    let data = handler.extract_data(&notification);
+    assert!(data.is_none());
+}

--- a/tests/unit/notification.rs
+++ b/tests/unit/notification.rs
@@ -11,7 +11,7 @@ fn test_notification_handler_new() {
 
 #[test]
 fn test_notification_handler_default() {
-    let handler = NotificationHandler::default();
+    let handler = NotificationHandler;
     assert!(format!("{:?}", handler).contains("NotificationHandler"));
 }
 
@@ -25,7 +25,7 @@ fn test_notification_handler_clone() {
 #[test]
 fn test_parse_notification_valid() {
     let handler = NotificationHandler::new();
-    
+
     let json = r#"{
         "jsonrpc": "2.0",
         "method": "subscription",
@@ -34,10 +34,10 @@ fn test_parse_notification_valid() {
             "data": {"price": 50000}
         }
     }"#;
-    
+
     let result = handler.parse_notification(json);
     assert!(result.is_ok());
-    
+
     let notification = result.unwrap();
     assert_eq!(notification.method, "subscription");
 }
@@ -45,9 +45,9 @@ fn test_parse_notification_valid() {
 #[test]
 fn test_parse_notification_invalid() {
     let handler = NotificationHandler::new();
-    
+
     let json = r#"not valid json"#;
-    
+
     let result = handler.parse_notification(json);
     assert!(result.is_err());
 }
@@ -55,42 +55,45 @@ fn test_parse_notification_invalid() {
 #[test]
 fn test_is_subscription_notification_true() {
     let handler = NotificationHandler::new();
-    
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: None,
     };
-    
+
     assert!(handler.is_subscription_notification(&notification));
 }
 
 #[test]
 fn test_is_subscription_notification_false() {
     let handler = NotificationHandler::new();
-    
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "heartbeat".to_string(),
         params: None,
     };
-    
+
     assert!(!handler.is_subscription_notification(&notification));
 }
 
 #[test]
 fn test_extract_channel_with_channel() {
     let handler = NotificationHandler::new();
-    
+
     let mut params = serde_json::Map::new();
-    params.insert("channel".to_string(), serde_json::json!("ticker.BTC-PERPETUAL"));
-    
+    params.insert(
+        "channel".to_string(),
+        serde_json::json!("ticker.BTC-PERPETUAL"),
+    );
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: Some(serde_json::Value::Object(params)),
     };
-    
+
     let channel = handler.extract_channel(&notification);
     assert_eq!(channel, Some("ticker.BTC-PERPETUAL".to_string()));
 }
@@ -98,13 +101,13 @@ fn test_extract_channel_with_channel() {
 #[test]
 fn test_extract_channel_no_params() {
     let handler = NotificationHandler::new();
-    
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: None,
     };
-    
+
     let channel = handler.extract_channel(&notification);
     assert!(channel.is_none());
 }
@@ -112,16 +115,16 @@ fn test_extract_channel_no_params() {
 #[test]
 fn test_extract_channel_no_channel_field() {
     let handler = NotificationHandler::new();
-    
+
     let mut params = serde_json::Map::new();
     params.insert("data".to_string(), serde_json::json!({"price": 50000}));
-    
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: Some(serde_json::Value::Object(params)),
     };
-    
+
     let channel = handler.extract_channel(&notification);
     assert!(channel.is_none());
 }
@@ -129,16 +132,16 @@ fn test_extract_channel_no_channel_field() {
 #[test]
 fn test_extract_data_with_data() {
     let handler = NotificationHandler::new();
-    
+
     let mut params = serde_json::Map::new();
     params.insert("data".to_string(), serde_json::json!({"price": 50000}));
-    
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: Some(serde_json::Value::Object(params)),
     };
-    
+
     let data = handler.extract_data(&notification);
     assert!(data.is_some());
     assert_eq!(data.unwrap()["price"], 50000);
@@ -147,13 +150,13 @@ fn test_extract_data_with_data() {
 #[test]
 fn test_extract_data_no_params() {
     let handler = NotificationHandler::new();
-    
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: None,
     };
-    
+
     let data = handler.extract_data(&notification);
     assert!(data.is_none());
 }
@@ -161,16 +164,19 @@ fn test_extract_data_no_params() {
 #[test]
 fn test_extract_data_no_data_field() {
     let handler = NotificationHandler::new();
-    
+
     let mut params = serde_json::Map::new();
-    params.insert("channel".to_string(), serde_json::json!("ticker.BTC-PERPETUAL"));
-    
+    params.insert(
+        "channel".to_string(),
+        serde_json::json!("ticker.BTC-PERPETUAL"),
+    );
+
     let notification = JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "subscription".to_string(),
         params: Some(serde_json::Value::Object(params)),
     };
-    
+
     let data = handler.extract_data(&notification);
     assert!(data.is_none());
 }

--- a/tests/unit/response.rs
+++ b/tests/unit/response.rs
@@ -11,7 +11,7 @@ fn test_response_handler_new() {
 
 #[test]
 fn test_response_handler_default() {
-    let handler = ResponseHandler::default();
+    let handler = ResponseHandler;
     assert!(format!("{:?}", handler).contains("ResponseHandler"));
 }
 
@@ -25,16 +25,16 @@ fn test_response_handler_clone() {
 #[test]
 fn test_parse_response_success() {
     let handler = ResponseHandler::new();
-    
+
     let json = r#"{
         "jsonrpc": "2.0",
         "id": 1,
         "result": {"version": "1.2.26"}
     }"#;
-    
+
     let result = handler.parse_response(json);
     assert!(result.is_ok());
-    
+
     let response = result.unwrap();
     assert_eq!(response.id.as_u64().unwrap(), 1);
 }
@@ -42,7 +42,7 @@ fn test_parse_response_success() {
 #[test]
 fn test_parse_response_error() {
     let handler = ResponseHandler::new();
-    
+
     let json = r#"{
         "jsonrpc": "2.0",
         "id": 1,
@@ -51,7 +51,7 @@ fn test_parse_response_error() {
             "message": "Invalid Request"
         }
     }"#;
-    
+
     let result = handler.parse_response(json);
     assert!(result.is_ok());
 }
@@ -59,9 +59,9 @@ fn test_parse_response_error() {
 #[test]
 fn test_parse_response_invalid() {
     let handler = ResponseHandler::new();
-    
+
     let json = r#"not valid json"#;
-    
+
     let result = handler.parse_response(json);
     assert!(result.is_err());
 }
@@ -69,7 +69,7 @@ fn test_parse_response_invalid() {
 #[test]
 fn test_is_success_true() {
     let handler = ResponseHandler::new();
-    
+
     let response = JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!(1),
@@ -77,14 +77,14 @@ fn test_is_success_true() {
             result: serde_json::json!({"version": "1.2.26"}),
         },
     };
-    
+
     assert!(handler.is_success(&response));
 }
 
 #[test]
 fn test_is_success_false() {
     let handler = ResponseHandler::new();
-    
+
     let response = JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!(1),
@@ -96,14 +96,14 @@ fn test_is_success_false() {
             },
         },
     };
-    
+
     assert!(!handler.is_success(&response));
 }
 
 #[test]
 fn test_extract_result_success() {
     let handler = ResponseHandler::new();
-    
+
     let response = JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!(1),
@@ -111,7 +111,7 @@ fn test_extract_result_success() {
             result: serde_json::json!({"version": "1.2.26"}),
         },
     };
-    
+
     let result = handler.extract_result(&response);
     assert!(result.is_some());
     assert_eq!(result.unwrap()["version"], "1.2.26");
@@ -120,7 +120,7 @@ fn test_extract_result_success() {
 #[test]
 fn test_extract_result_error() {
     let handler = ResponseHandler::new();
-    
+
     let response = JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!(1),
@@ -132,7 +132,7 @@ fn test_extract_result_error() {
             },
         },
     };
-    
+
     let result = handler.extract_result(&response);
     assert!(result.is_none());
 }
@@ -140,7 +140,7 @@ fn test_extract_result_error() {
 #[test]
 fn test_extract_error_success() {
     let handler = ResponseHandler::new();
-    
+
     let response = JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!(1),
@@ -148,7 +148,7 @@ fn test_extract_error_success() {
             result: serde_json::json!({"version": "1.2.26"}),
         },
     };
-    
+
     let error = handler.extract_error(&response);
     assert!(error.is_none());
 }
@@ -156,7 +156,7 @@ fn test_extract_error_success() {
 #[test]
 fn test_extract_error_error() {
     let handler = ResponseHandler::new();
-    
+
     let response = JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!(1),
@@ -168,7 +168,7 @@ fn test_extract_error_error() {
             },
         },
     };
-    
+
     let error = handler.extract_error(&response);
     assert!(error.is_some());
     assert_eq!(error.unwrap().code, -32600);

--- a/tests/unit/response.rs
+++ b/tests/unit/response.rs
@@ -1,0 +1,176 @@
+//! Unit tests for message/response.rs
+
+use deribit_websocket::message::ResponseHandler;
+use deribit_websocket::model::ws_types::{JsonRpcError, JsonRpcResponse, JsonRpcResult};
+
+#[test]
+fn test_response_handler_new() {
+    let handler = ResponseHandler::new();
+    assert!(format!("{:?}", handler).contains("ResponseHandler"));
+}
+
+#[test]
+fn test_response_handler_default() {
+    let handler = ResponseHandler::default();
+    assert!(format!("{:?}", handler).contains("ResponseHandler"));
+}
+
+#[test]
+fn test_response_handler_clone() {
+    let handler = ResponseHandler::new();
+    let cloned = handler.clone();
+    assert!(format!("{:?}", cloned).contains("ResponseHandler"));
+}
+
+#[test]
+fn test_parse_response_success() {
+    let handler = ResponseHandler::new();
+    
+    let json = r#"{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"version": "1.2.26"}
+    }"#;
+    
+    let result = handler.parse_response(json);
+    assert!(result.is_ok());
+    
+    let response = result.unwrap();
+    assert_eq!(response.id.as_u64().unwrap(), 1);
+}
+
+#[test]
+fn test_parse_response_error() {
+    let handler = ResponseHandler::new();
+    
+    let json = r#"{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": -32600,
+            "message": "Invalid Request"
+        }
+    }"#;
+    
+    let result = handler.parse_response(json);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_parse_response_invalid() {
+    let handler = ResponseHandler::new();
+    
+    let json = r#"not valid json"#;
+    
+    let result = handler.parse_response(json);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_is_success_true() {
+    let handler = ResponseHandler::new();
+    
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        result: JsonRpcResult::Success {
+            result: serde_json::json!({"version": "1.2.26"}),
+        },
+    };
+    
+    assert!(handler.is_success(&response));
+}
+
+#[test]
+fn test_is_success_false() {
+    let handler = ResponseHandler::new();
+    
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        result: JsonRpcResult::Error {
+            error: JsonRpcError {
+                code: -32600,
+                message: "Invalid Request".to_string(),
+                data: None,
+            },
+        },
+    };
+    
+    assert!(!handler.is_success(&response));
+}
+
+#[test]
+fn test_extract_result_success() {
+    let handler = ResponseHandler::new();
+    
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        result: JsonRpcResult::Success {
+            result: serde_json::json!({"version": "1.2.26"}),
+        },
+    };
+    
+    let result = handler.extract_result(&response);
+    assert!(result.is_some());
+    assert_eq!(result.unwrap()["version"], "1.2.26");
+}
+
+#[test]
+fn test_extract_result_error() {
+    let handler = ResponseHandler::new();
+    
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        result: JsonRpcResult::Error {
+            error: JsonRpcError {
+                code: -32600,
+                message: "Invalid Request".to_string(),
+                data: None,
+            },
+        },
+    };
+    
+    let result = handler.extract_result(&response);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_extract_error_success() {
+    let handler = ResponseHandler::new();
+    
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        result: JsonRpcResult::Success {
+            result: serde_json::json!({"version": "1.2.26"}),
+        },
+    };
+    
+    let error = handler.extract_error(&response);
+    assert!(error.is_none());
+}
+
+#[test]
+fn test_extract_error_error() {
+    let handler = ResponseHandler::new();
+    
+    let response = JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        result: JsonRpcResult::Error {
+            error: JsonRpcError {
+                code: -32600,
+                message: "Invalid Request".to_string(),
+                data: None,
+            },
+        },
+    };
+    
+    let error = handler.extract_error(&response);
+    assert!(error.is_some());
+    assert_eq!(error.unwrap().code, -32600);
+    assert_eq!(error.unwrap().message, "Invalid Request");
+}

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -58,3 +58,122 @@ fn test_websocket_session_debug_format() {
     let debug_output = format!("{:?}", session);
     assert!(debug_output.contains("WebSocketSession"));
 }
+
+#[test]
+fn test_websocket_session_config_access() {
+    let config = WebSocketConfig::default()
+        .with_heartbeat_interval(std::time::Duration::from_secs(45));
+
+    let session = WebSocketSession::new(config);
+
+    // Test that config can be accessed
+    let config_ref = session.config();
+    assert!(format!("{:?}", config_ref).contains("WebSocketConfig"));
+}
+
+#[test]
+fn test_websocket_session_subscription_manager() {
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    // Test that subscription manager can be accessed
+    let manager = session.subscription_manager();
+    assert!(format!("{:?}", manager).contains("Mutex"));
+}
+
+#[tokio::test]
+async fn test_websocket_session_state() {
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    // Initial state should be Disconnected
+    let state = session.state().await;
+    assert!(format!("{:?}", state).contains("Disconnected"));
+}
+
+#[tokio::test]
+async fn test_websocket_session_set_state() {
+    use deribit_websocket::model::ConnectionState;
+
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    // Set state to Connected
+    session.set_state(ConnectionState::Connected).await;
+    let state = session.state().await;
+    assert!(matches!(state, ConnectionState::Connected));
+}
+
+#[tokio::test]
+async fn test_websocket_session_is_connected_false() {
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    // Initial state is Disconnected, so is_connected should be false
+    assert!(!session.is_connected().await);
+}
+
+#[tokio::test]
+async fn test_websocket_session_is_connected_true() {
+    use deribit_websocket::model::ConnectionState;
+
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    session.set_state(ConnectionState::Connected).await;
+    assert!(session.is_connected().await);
+}
+
+#[tokio::test]
+async fn test_websocket_session_is_authenticated_false() {
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    assert!(!session.is_authenticated().await);
+}
+
+#[tokio::test]
+async fn test_websocket_session_is_authenticated_true() {
+    use deribit_websocket::model::ConnectionState;
+
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    session.set_state(ConnectionState::Authenticated).await;
+    assert!(session.is_authenticated().await);
+}
+
+#[tokio::test]
+async fn test_websocket_session_mark_authenticated() {
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    session.mark_authenticated().await;
+    assert!(session.is_authenticated().await);
+}
+
+#[tokio::test]
+async fn test_websocket_session_mark_disconnected() {
+    use deribit_websocket::model::ConnectionState;
+
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    // First connect and authenticate
+    session.set_state(ConnectionState::Authenticated).await;
+    assert!(session.is_authenticated().await);
+
+    // Then disconnect
+    session.mark_disconnected().await;
+    assert!(!session.is_connected().await);
+    assert!(!session.is_authenticated().await);
+}
+
+#[tokio::test]
+async fn test_websocket_session_reactivate_subscriptions() {
+    let config = WebSocketConfig::default();
+    let session = WebSocketSession::new(config);
+
+    // This should not panic
+    session.reactivate_subscriptions().await;
+}

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -61,8 +61,8 @@ fn test_websocket_session_debug_format() {
 
 #[test]
 fn test_websocket_session_config_access() {
-    let config = WebSocketConfig::default()
-        .with_heartbeat_interval(std::time::Duration::from_secs(45));
+    let config =
+        WebSocketConfig::default().with_heartbeat_interval(std::time::Duration::from_secs(45));
 
     let session = WebSocketSession::new(config);
 

--- a/tests/unit/subscriptions.rs
+++ b/tests/unit/subscriptions.rs
@@ -233,3 +233,424 @@ fn test_request_builder_unsubscribe_all_incremental_ids() {
     assert_eq!(r1.id, serde_json::json!(1));
     assert_eq!(r2.id, serde_json::json!(2));
 }
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_ticker() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    let channels = manager.get_all_channels();
+    assert_eq!(channels.len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_orderbook() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_trades() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::Trades("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_incremental_ticker() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::IncrementalTicker("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_chart_trades() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::ChartTrades {
+        instrument: "BTC-PERPETUAL".to_string(),
+        resolution: "1".to_string(),
+    };
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_grouped_orderbook() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::GroupedOrderBook {
+        instrument: "BTC-PERPETUAL".to_string(),
+        group: "5".to_string(),
+        depth: "10".to_string(),
+        interval: "100ms".to_string(),
+    };
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_changes() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserChanges {
+        instrument: "BTC-PERPETUAL".to_string(),
+        interval: "raw".to_string(),
+    };
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_trades_by_kind() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::TradesByKind {
+        currency: "BTC".to_string(),
+        kind: "future".to_string(),
+        interval: "raw".to_string(),
+    };
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_price_index() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::PriceIndex("btc_usd".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_price_ranking() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::PriceRanking("btc_usd".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_price_statistics() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::PriceStatistics("btc_usd".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_volatility_index() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::VolatilityIndex("btc_usd".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_estimated_expiration() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::EstimatedExpirationPrice("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_mark_price() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::MarkPrice("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_funding() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::Funding("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_quote() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::Quote("BTC-PERPETUAL".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_perpetual() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::Perpetual {
+        instrument: "BTC-PERPETUAL".to_string(),
+        interval: "100ms".to_string(),
+    };
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_instrument_state() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::InstrumentState {
+        currency: "BTC".to_string(),
+        kind: "future".to_string(),
+    };
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_block_rfq() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_block_trade_confirmations_currency() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_mmp_trigger() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_orders() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserOrders;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_trades() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserTrades;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_portfolio() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserPortfolio;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_platform_state() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::PlatformState;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_platform_state_public() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::PlatformStatePublicMethods;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_block_trade_confirmations() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::BlockTradeConfirmations;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_access_log() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserAccessLog;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_user_lock() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::UserLock;
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_add_subscription_from_channel_unknown() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = SubscriptionChannel::Unknown("custom.channel".to_string());
+    manager.add_subscription_from_channel(channel);
+    
+    assert_eq!(manager.get_all_channels().len(), 1);
+}
+
+#[test]
+fn test_subscription_manager_get_subscription() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = "ticker.BTC-PERPETUAL".to_string();
+    let channel_type = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
+    manager.add_subscription(channel.clone(), channel_type, Some("BTC-PERPETUAL".to_string()));
+    
+    let subscription = manager.get_subscription(&channel);
+    assert!(subscription.is_some());
+    assert_eq!(subscription.unwrap().channel, channel);
+}
+
+#[test]
+fn test_subscription_manager_get_subscription_not_found() {
+    let manager = SubscriptionManager::new();
+    
+    let subscription = manager.get_subscription("nonexistent");
+    assert!(subscription.is_none());
+}
+
+#[test]
+fn test_subscription_manager_deactivate_subscription() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel = "ticker.BTC-PERPETUAL".to_string();
+    let channel_type = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
+    manager.add_subscription(channel.clone(), channel_type, Some("BTC-PERPETUAL".to_string()));
+    
+    // Should be active by default
+    assert_eq!(manager.active_subscriptions().len(), 1);
+    
+    manager.deactivate_subscription(&channel);
+    
+    // Should now be inactive
+    assert_eq!(manager.active_subscriptions().len(), 0);
+}
+
+#[test]
+fn test_subscription_manager_deactivate_nonexistent() {
+    let mut manager = SubscriptionManager::new();
+    
+    // Should not panic
+    manager.deactivate_subscription("nonexistent");
+}
+
+#[test]
+fn test_subscription_manager_reactivate_all() {
+    let mut manager = SubscriptionManager::new();
+    
+    // Add and deactivate subscriptions
+    let channel1 = "ticker.BTC-PERPETUAL".to_string();
+    let channel2 = "book.ETH-PERPETUAL.100ms".to_string();
+    
+    manager.add_subscription(channel1.clone(), SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()), None);
+    manager.add_subscription(channel2.clone(), SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()), None);
+    
+    manager.deactivate_subscription(&channel1);
+    manager.deactivate_subscription(&channel2);
+    
+    assert_eq!(manager.active_subscriptions().len(), 0);
+    
+    manager.reactivate_all();
+    
+    assert_eq!(manager.active_subscriptions().len(), 2);
+}
+
+#[test]
+fn test_subscription_manager_get_active_channels() {
+    let mut manager = SubscriptionManager::new();
+    
+    let channel1 = "ticker.BTC-PERPETUAL".to_string();
+    let channel2 = "book.ETH-PERPETUAL.100ms".to_string();
+    
+    manager.add_subscription(channel1.clone(), SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()), None);
+    manager.add_subscription(channel2.clone(), SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()), None);
+    
+    manager.deactivate_subscription(&channel1);
+    
+    let active_channels = manager.get_active_channels();
+    assert_eq!(active_channels.len(), 1);
+    assert!(active_channels.contains(&channel2));
+}
+
+#[test]
+fn test_subscription_manager_active_subscriptions() {
+    let mut manager = SubscriptionManager::new();
+    
+    manager.add_subscription(
+        "ticker.BTC-PERPETUAL".to_string(),
+        SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+        Some("BTC-PERPETUAL".to_string()),
+    );
+    
+    let active = manager.active_subscriptions();
+    assert_eq!(active.len(), 1);
+    assert!(active[0].active);
+}

--- a/tests/unit/subscriptions.rs
+++ b/tests/unit/subscriptions.rs
@@ -237,10 +237,10 @@ fn test_request_builder_unsubscribe_all_incremental_ids() {
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_ticker() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     let channels = manager.get_all_channels();
     assert_eq!(channels.len(), 1);
 }
@@ -248,50 +248,50 @@ fn test_subscription_manager_add_subscription_from_channel_ticker() {
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_orderbook() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_trades() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::Trades("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_incremental_ticker() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::IncrementalTicker("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_chart_trades() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::ChartTrades {
         instrument: "BTC-PERPETUAL".to_string(),
         resolution: "1".to_string(),
     };
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_grouped_orderbook() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::GroupedOrderBook {
         instrument: "BTC-PERPETUAL".to_string(),
         group: "5".to_string(),
@@ -299,271 +299,275 @@ fn test_subscription_manager_add_subscription_from_channel_grouped_orderbook() {
         interval: "100ms".to_string(),
     };
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_changes() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserChanges {
         instrument: "BTC-PERPETUAL".to_string(),
         interval: "raw".to_string(),
     };
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_trades_by_kind() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::TradesByKind {
         currency: "BTC".to_string(),
         kind: "future".to_string(),
         interval: "raw".to_string(),
     };
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_price_index() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::PriceIndex("btc_usd".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_price_ranking() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::PriceRanking("btc_usd".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_price_statistics() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::PriceStatistics("btc_usd".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_volatility_index() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::VolatilityIndex("btc_usd".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_estimated_expiration() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::EstimatedExpirationPrice("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_mark_price() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::MarkPrice("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_funding() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::Funding("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_quote() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::Quote("BTC-PERPETUAL".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_perpetual() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::Perpetual {
         instrument: "BTC-PERPETUAL".to_string(),
         interval: "100ms".to_string(),
     };
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_instrument_state() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::InstrumentState {
         currency: "BTC".to_string(),
         kind: "future".to_string(),
     };
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_block_rfq() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::BlockRfqTrades("BTC".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_block_trade_confirmations_currency() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::BlockTradeConfirmationsByCurrency("BTC".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_mmp_trigger() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserMmpTrigger("btc_usd".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_orders() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserOrders;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_trades() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserTrades;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_portfolio() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserPortfolio;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_platform_state() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::PlatformState;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_platform_state_public() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::PlatformStatePublicMethods;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_block_trade_confirmations() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::BlockTradeConfirmations;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_access_log() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserAccessLog;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_user_lock() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::UserLock;
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_add_subscription_from_channel_unknown() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = SubscriptionChannel::Unknown("custom.channel".to_string());
     manager.add_subscription_from_channel(channel);
-    
+
     assert_eq!(manager.get_all_channels().len(), 1);
 }
 
 #[test]
 fn test_subscription_manager_get_subscription() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = "ticker.BTC-PERPETUAL".to_string();
     let channel_type = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
-    manager.add_subscription(channel.clone(), channel_type, Some("BTC-PERPETUAL".to_string()));
-    
+    manager.add_subscription(
+        channel.clone(),
+        channel_type,
+        Some("BTC-PERPETUAL".to_string()),
+    );
+
     let subscription = manager.get_subscription(&channel);
     assert!(subscription.is_some());
     assert_eq!(subscription.unwrap().channel, channel);
@@ -572,7 +576,7 @@ fn test_subscription_manager_get_subscription() {
 #[test]
 fn test_subscription_manager_get_subscription_not_found() {
     let manager = SubscriptionManager::new();
-    
+
     let subscription = manager.get_subscription("nonexistent");
     assert!(subscription.is_none());
 }
@@ -580,16 +584,20 @@ fn test_subscription_manager_get_subscription_not_found() {
 #[test]
 fn test_subscription_manager_deactivate_subscription() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel = "ticker.BTC-PERPETUAL".to_string();
     let channel_type = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
-    manager.add_subscription(channel.clone(), channel_type, Some("BTC-PERPETUAL".to_string()));
-    
+    manager.add_subscription(
+        channel.clone(),
+        channel_type,
+        Some("BTC-PERPETUAL".to_string()),
+    );
+
     // Should be active by default
     assert_eq!(manager.active_subscriptions().len(), 1);
-    
+
     manager.deactivate_subscription(&channel);
-    
+
     // Should now be inactive
     assert_eq!(manager.active_subscriptions().len(), 0);
 }
@@ -597,7 +605,7 @@ fn test_subscription_manager_deactivate_subscription() {
 #[test]
 fn test_subscription_manager_deactivate_nonexistent() {
     let mut manager = SubscriptionManager::new();
-    
+
     // Should not panic
     manager.deactivate_subscription("nonexistent");
 }
@@ -605,36 +613,52 @@ fn test_subscription_manager_deactivate_nonexistent() {
 #[test]
 fn test_subscription_manager_reactivate_all() {
     let mut manager = SubscriptionManager::new();
-    
+
     // Add and deactivate subscriptions
     let channel1 = "ticker.BTC-PERPETUAL".to_string();
     let channel2 = "book.ETH-PERPETUAL.100ms".to_string();
-    
-    manager.add_subscription(channel1.clone(), SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()), None);
-    manager.add_subscription(channel2.clone(), SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()), None);
-    
+
+    manager.add_subscription(
+        channel1.clone(),
+        SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+        None,
+    );
+    manager.add_subscription(
+        channel2.clone(),
+        SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()),
+        None,
+    );
+
     manager.deactivate_subscription(&channel1);
     manager.deactivate_subscription(&channel2);
-    
+
     assert_eq!(manager.active_subscriptions().len(), 0);
-    
+
     manager.reactivate_all();
-    
+
     assert_eq!(manager.active_subscriptions().len(), 2);
 }
 
 #[test]
 fn test_subscription_manager_get_active_channels() {
     let mut manager = SubscriptionManager::new();
-    
+
     let channel1 = "ticker.BTC-PERPETUAL".to_string();
     let channel2 = "book.ETH-PERPETUAL.100ms".to_string();
-    
-    manager.add_subscription(channel1.clone(), SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()), None);
-    manager.add_subscription(channel2.clone(), SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()), None);
-    
+
+    manager.add_subscription(
+        channel1.clone(),
+        SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+        None,
+    );
+    manager.add_subscription(
+        channel2.clone(),
+        SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()),
+        None,
+    );
+
     manager.deactivate_subscription(&channel1);
-    
+
     let active_channels = manager.get_active_channels();
     assert_eq!(active_channels.len(), 1);
     assert!(active_channels.contains(&channel2));
@@ -643,13 +667,13 @@ fn test_subscription_manager_get_active_channels() {
 #[test]
 fn test_subscription_manager_active_subscriptions() {
     let mut manager = SubscriptionManager::new();
-    
+
     manager.add_subscription(
         "ticker.BTC-PERPETUAL".to_string(),
         SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
         Some("BTC-PERPETUAL".to_string()),
     );
-    
+
     let active = manager.active_subscriptions();
     assert_eq!(active.len(), 1);
     assert!(active[0].active);

--- a/tests/unit/subscriptions_legacy.rs
+++ b/tests/unit/subscriptions_legacy.rs
@@ -1,0 +1,63 @@
+//! Unit tests for subscriptions.rs (legacy SubscriptionChannel)
+
+#[allow(deprecated)]
+use deribit_websocket::subscriptions::SubscriptionChannel;
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_ticker_display() {
+    let channel = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
+    assert_eq!(format!("{}", channel), "ticker.BTC-PERPETUAL.raw");
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_orderbook_display() {
+    let channel = SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string());
+    assert_eq!(format!("{}", channel), "book.ETH-PERPETUAL.raw");
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_trades_display() {
+    let channel = SubscriptionChannel::Trades("BTC-PERPETUAL".to_string());
+    assert_eq!(format!("{}", channel), "trades.BTC-PERPETUAL.raw");
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_user_orders_display() {
+    let channel = SubscriptionChannel::UserOrders;
+    assert_eq!(format!("{}", channel), "user.orders.any.any.raw");
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_user_trades_display() {
+    let channel = SubscriptionChannel::UserTrades;
+    assert_eq!(format!("{}", channel), "user.trades.any.any.raw");
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_unknown_display() {
+    let channel = SubscriptionChannel::Unknown("custom.channel".to_string());
+    assert_eq!(format!("{}", channel), "custom.channel");
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_debug() {
+    let channel = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
+    let debug = format!("{:?}", channel);
+    assert!(debug.contains("Ticker"));
+    assert!(debug.contains("BTC-PERPETUAL"));
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_subscription_channel_clone() {
+    let channel = SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string());
+    let cloned = channel.clone();
+    assert_eq!(format!("{}", cloned), "ticker.BTC-PERPETUAL.raw");
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive examples for v0.2.0 features and significantly improves test coverage.

### Examples Added (22 total)
- Trading operations: buy, sell, edit, cancel orders
- Account management: summary, positions
- Session management: hello, test connection
- Subscription management: new channels, unsubscribe_all

### Test Coverage Improvement: 42.70% → 53.41% (+10.71%)

| Module | Before | After |
|--------|--------|-------|
| message/builder.rs | 0% | 100% |
| subscriptions.rs | 0% | 100% |
| message/notification.rs | 11% | 100% |
| message/response.rs | 12% | 100% |
| session/ws_session.rs | 17% | 100% |
| model/subscription.rs | 26% | 90% |
| config.rs | 58% | 98% |

### New Test Files
- tests/unit/builder.rs
- tests/unit/subscriptions_legacy.rs
- tests/unit/notification.rs
- tests/unit/response.rs

### Documentation
- Updated lib.rs with v0.2.0 features and examples
- Regenerated README.md

### Other Changes
- Fixed Makefile to exclude integration-tests from coverage (they require .env credentials)

**407 tests passing** ✓