### PR TITLE
fix(connection): replace receive recursion with flat loop (#42)

### DIFF
--- a/src/connection/ws_connection.rs
+++ b/src/connection/ws_connection.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_receive_skips_ping_frames_then_returns_text() {
-        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+        let (addr, server) = spawn_mock_server(|mut sink| async move {
             for _ in 0..10_000 {
                 if sink.send(Message::Ping(Vec::new().into())).await.is_err() {
                     return;
@@ -189,11 +189,13 @@ mod tests {
         let mut client = connect_client(addr).await;
         let received = client.receive().await.expect("receive returns the text");
         assert_eq!(received, "payload");
+        drop(client);
+        server.await.expect("server task did not panic");
     }
 
     #[tokio::test]
     async fn test_receive_skips_binary_frames_then_returns_text() {
-        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+        let (addr, server) = spawn_mock_server(|mut sink| async move {
             for _ in 0..100 {
                 if sink
                     .send(Message::Binary(vec![1, 2, 3].into()))
@@ -210,11 +212,13 @@ mod tests {
         let mut client = connect_client(addr).await;
         let received = client.receive().await.expect("receive returns the text");
         assert_eq!(received, "payload");
+        drop(client);
+        server.await.expect("server task did not panic");
     }
 
     #[tokio::test]
     async fn test_receive_skips_pong_frames_then_returns_text() {
-        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+        let (addr, server) = spawn_mock_server(|mut sink| async move {
             for _ in 0..100 {
                 if sink.send(Message::Pong(Vec::new().into())).await.is_err() {
                     return;
@@ -227,11 +231,13 @@ mod tests {
         let mut client = connect_client(addr).await;
         let received = client.receive().await.expect("receive returns the text");
         assert_eq!(received, "payload");
+        drop(client);
+        server.await.expect("server task did not panic");
     }
 
     #[tokio::test]
     async fn test_receive_returns_closed_on_close_frame() {
-        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+        let (addr, server) = spawn_mock_server(|mut sink| async move {
             let _ = sink.send(Message::Close(None)).await;
             let _ = sink.close().await;
         })
@@ -248,11 +254,13 @@ mod tests {
             !client.is_connected(),
             "stream should be cleared after close frame"
         );
+        drop(client);
+        server.await.expect("server task did not panic");
     }
 
     #[tokio::test]
     async fn test_receive_skips_mixed_non_text_frames() {
-        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+        let (addr, server) = spawn_mock_server(|mut sink| async move {
             for _ in 0..200 {
                 if sink.send(Message::Ping(Vec::new().into())).await.is_err() {
                     return;
@@ -275,5 +283,7 @@ mod tests {
         let mut client = connect_client(addr).await;
         let received = client.receive().await.expect("receive returns the text");
         assert_eq!(received, "payload");
+        drop(client);
+        server.await.expect("server task did not panic");
     }
 }

--- a/src/connection/ws_connection.rs
+++ b/src/connection/ws_connection.rs
@@ -65,26 +65,33 @@ impl WebSocketConnection {
     /// Receive a message
     pub async fn receive(&mut self) -> Result<String, WebSocketError> {
         if let Some(stream) = &mut self.stream {
-            match stream.next().await {
-                Some(Ok(Message::Text(text))) => Ok(text.to_string()),
-                Some(Ok(Message::Close(_))) => {
-                    self.stream = None;
-                    Err(WebSocketError::ConnectionClosed)
-                }
-                Some(Ok(_)) => {
-                    // Skip non-text messages (binary, ping, pong) - try again
-                    Box::pin(self.receive()).await
-                }
-                Some(Err(e)) => {
-                    self.stream = None;
-                    Err(WebSocketError::ConnectionFailed(format!(
-                        "Failed to receive message: {}",
-                        e
-                    )))
-                }
-                None => {
-                    self.stream = None;
-                    Err(WebSocketError::ConnectionClosed)
+            loop {
+                match stream.next().await {
+                    Some(Ok(Message::Text(text))) => return Ok(text.to_string()),
+                    Some(Ok(
+                        Message::Binary(_)
+                        | Message::Ping(_)
+                        | Message::Pong(_)
+                        | Message::Frame(_),
+                    )) => {
+                        // Skip non-text frames and continue draining the stream.
+                        continue;
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        self.stream = None;
+                        return Err(WebSocketError::ConnectionClosed);
+                    }
+                    Some(Err(e)) => {
+                        self.stream = None;
+                        return Err(WebSocketError::ConnectionFailed(format!(
+                            "Failed to receive message: {}",
+                            e
+                        )));
+                    }
+                    None => {
+                        self.stream = None;
+                        return Err(WebSocketError::ConnectionClosed);
+                    }
                 }
             }
         } else {
@@ -95,5 +102,178 @@ impl WebSocketConnection {
     /// Get the connection URL
     pub fn url(&self) -> &Url {
         &self.url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use std::net::SocketAddr;
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::Message;
+
+    /// Spawn a local WebSocket server that accepts a single connection and
+    /// runs `send_frames` over the server sink. A concurrent read-drain task
+    /// keeps the peer side from blocking on auto-pong back-pressure. Returns
+    /// the bound address and a `JoinHandle` for the acceptor task.
+    async fn spawn_mock_server<F, Fut>(send_frames: F) -> (SocketAddr, JoinHandle<()>)
+    where
+        F: FnOnce(
+                futures_util::stream::SplitSink<WebSocketStream<tokio::net::TcpStream>, Message>,
+            ) -> Fut
+            + Send
+            + 'static,
+        Fut: std::future::Future<Output = ()> + Send,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind localhost ephemeral port");
+        let addr = listener
+            .local_addr()
+            .expect("read local addr of bound listener");
+        let handle = tokio::spawn(async move {
+            let (socket, _peer) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => return,
+            };
+            let ws = match accept_async(socket).await {
+                Ok(ws) => ws,
+                Err(_) => return,
+            };
+            let (sink, mut stream) = ws.split();
+            // Drain anything the client sends (including auto-pongs from
+            // tungstenite) so the client's write side never blocks on a
+            // full socket buffer. The drain task exits when the client
+            // disconnects at end of test.
+            let drain = tokio::spawn(async move {
+                while let Some(msg) = stream.next().await {
+                    if msg.is_err() {
+                        break;
+                    }
+                }
+            });
+            send_frames(sink).await;
+            let _ = drain.await;
+        });
+        (addr, handle)
+    }
+
+    fn ws_url(addr: SocketAddr) -> Url {
+        Url::parse(&format!("ws://{}/", addr)).expect("valid ws url")
+    }
+
+    async fn connect_client(addr: SocketAddr) -> WebSocketConnection {
+        let mut client = WebSocketConnection::new(ws_url(addr));
+        client
+            .connect()
+            .await
+            .expect("client connects to mock server");
+        client
+    }
+
+    #[tokio::test]
+    async fn test_receive_skips_ping_frames_then_returns_text() {
+        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+            for _ in 0..10_000 {
+                if sink.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    return;
+                }
+            }
+            let _ = sink.send(Message::Text("payload".into())).await;
+        })
+        .await;
+
+        let mut client = connect_client(addr).await;
+        let received = client.receive().await.expect("receive returns the text");
+        assert_eq!(received, "payload");
+    }
+
+    #[tokio::test]
+    async fn test_receive_skips_binary_frames_then_returns_text() {
+        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+            for _ in 0..100 {
+                if sink
+                    .send(Message::Binary(vec![1, 2, 3].into()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            let _ = sink.send(Message::Text("payload".into())).await;
+        })
+        .await;
+
+        let mut client = connect_client(addr).await;
+        let received = client.receive().await.expect("receive returns the text");
+        assert_eq!(received, "payload");
+    }
+
+    #[tokio::test]
+    async fn test_receive_skips_pong_frames_then_returns_text() {
+        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+            for _ in 0..100 {
+                if sink.send(Message::Pong(Vec::new().into())).await.is_err() {
+                    return;
+                }
+            }
+            let _ = sink.send(Message::Text("payload".into())).await;
+        })
+        .await;
+
+        let mut client = connect_client(addr).await;
+        let received = client.receive().await.expect("receive returns the text");
+        assert_eq!(received, "payload");
+    }
+
+    #[tokio::test]
+    async fn test_receive_returns_closed_on_close_frame() {
+        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+            let _ = sink.send(Message::Close(None)).await;
+            let _ = sink.close().await;
+        })
+        .await;
+
+        let mut client = connect_client(addr).await;
+        let result = client.receive().await;
+        assert!(
+            matches!(result, Err(WebSocketError::ConnectionClosed)),
+            "expected ConnectionClosed, got {:?}",
+            result
+        );
+        assert!(
+            !client.is_connected(),
+            "stream should be cleared after close frame"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_receive_skips_mixed_non_text_frames() {
+        let (addr, _server) = spawn_mock_server(|mut sink| async move {
+            for _ in 0..200 {
+                if sink.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    return;
+                }
+                if sink
+                    .send(Message::Binary(vec![9, 9, 9].into()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                if sink.send(Message::Pong(Vec::new().into())).await.is_err() {
+                    return;
+                }
+            }
+            let _ = sink.send(Message::Text("payload".into())).await;
+        })
+        .await;
+
+        let mut client = connect_client(addr).await;
+        let received = client.receive().await.expect("receive returns the text");
+        assert_eq!(received, "payload");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #42.

`WebSocketConnection::receive` skipped non-text frames via `Box::pin(self.receive()).await`. Each skipped frame allocated a boxed future and added a stack frame, so sustained ping/pong/binary traffic caused unbounded heap and stack growth — a realistic DoS surface under heavy market-data subscriptions.

Replace the recursion with `loop { match stream.next().await { ... } }` that exhaustively matches all `Message` variants.

## Behavior

Identical outside the recursion:
- `Text` → return.
- `Binary | Ping | Pong | Frame` → `continue` (skip and keep draining).
- `Close` → clear `self.stream`, return `ConnectionClosed`.
- stream `Err` → clear `self.stream`, return `ConnectionFailed` with existing message format.
- `None` → clear `self.stream`, return `ConnectionClosed`.

No signature change, no new error variants, no timeout (that is #50), no logging added.

## Tests

5 new `#[tokio::test]` unit tests in `src/connection/ws_connection.rs`, using a local `tokio::net::TcpListener` + `tokio_tungstenite::accept_async` mock server (no external deps added):

1. `test_receive_skips_ping_frames_then_returns_text` — 10 000 pings + 1 text.
2. `test_receive_skips_binary_frames_then_returns_text` — 100 binary + 1 text.
3. `test_receive_skips_pong_frames_then_returns_text` — 100 pongs + 1 text.
4. `test_receive_returns_closed_on_close_frame` — close frame yields `ConnectionClosed`, stream cleared.
5. `test_receive_skips_mixed_non_text_frames` — 200 × {ping, binary, pong} interleaved + 1 text.

The mock server helper runs a concurrent read-drain task so the client's auto-pong traffic does not block under the 10k ping flood.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --workspace` — 407 passed, 0 failed (5 new)
- [x] `cargo build --release`
- [x] Architect review — module boundaries clean, no `doc/` update needed