### PR TITLE
fix(session): share single SubscriptionManager between client and session (#43)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -45,7 +45,11 @@ impl DeribitWebSocketClient {
     /// Create a new WebSocket client
     pub fn new(config: &WebSocketConfig) -> Result<Self, WebSocketError> {
         let connection = Arc::new(Mutex::new(WebSocketConnection::new(config.ws_url.clone())));
-        let session = Arc::new(WebSocketSession::new(config.clone()));
+        let subscription_manager = Arc::new(Mutex::new(SubscriptionManager::new()));
+        let session = Arc::new(WebSocketSession::new(
+            config.clone(),
+            Arc::clone(&subscription_manager),
+        ));
         let (tx, rx) = mpsc::unbounded_channel();
 
         let config = Arc::new(config.clone());
@@ -56,11 +60,19 @@ impl DeribitWebSocketClient {
             request_builder: Arc::new(Mutex::new(RequestBuilder::new())),
             response_handler: Arc::new(ResponseHandler::new()),
             notification_handler: Arc::new(NotificationHandler::new()),
-            subscription_manager: Arc::new(Mutex::new(SubscriptionManager::new())),
+            subscription_manager,
             message_sender: Some(tx),
             message_receiver: Some(rx),
             message_handler: None,
         })
+    }
+
+    /// Returns a handle to the shared subscription manager. The same
+    /// handle is held by `self.session`, so all subscription state is
+    /// observable from either side.
+    #[must_use]
+    pub fn subscription_manager(&self) -> Arc<Mutex<SubscriptionManager>> {
+        Arc::clone(&self.subscription_manager)
     }
 
     /// Create a new WebSocket client with default configuration

--- a/src/model/subscription.rs
+++ b/src/model/subscription.rs
@@ -119,6 +119,14 @@ impl SubscriptionManager {
         }
     }
 
+    /// Deactivate all subscriptions in place. Entries are preserved so a
+    /// later call to `reactivate_all` can restore them on reconnect.
+    pub fn deactivate_all(&mut self) {
+        for subscription in self.subscriptions.values_mut() {
+            subscription.active = false;
+        }
+    }
+
     /// Clear all subscriptions
     pub fn clear(&mut self) {
         self.subscriptions.clear();

--- a/src/session/ws_session.rs
+++ b/src/session/ws_session.rs
@@ -16,11 +16,14 @@ pub struct WebSocketSession {
 
 impl WebSocketSession {
     /// Create a new WebSocket session
-    pub fn new(config: WebSocketConfig) -> Self {
+    pub fn new(
+        config: WebSocketConfig,
+        subscription_manager: Arc<Mutex<SubscriptionManager>>,
+    ) -> Self {
         Self {
             config: Arc::new(config),
             state: Arc::new(Mutex::new(ConnectionState::Disconnected)),
-            subscription_manager: Arc::new(Mutex::new(SubscriptionManager::new())),
+            subscription_manager,
         }
     }
 

--- a/src/session/ws_session.rs
+++ b/src/session/ws_session.rs
@@ -68,8 +68,9 @@ impl WebSocketSession {
     /// Mark session as disconnected
     pub async fn mark_disconnected(&self) {
         self.set_state(ConnectionState::Disconnected).await;
-        // Deactivate all subscriptions
-        self.subscription_manager.lock().await.clear();
+        // Deactivate all subscriptions but preserve their entries so
+        // `reactivate_subscriptions` can restore them on reconnect.
+        self.subscription_manager.lock().await.deactivate_all();
     }
 
     /// Reactivate subscriptions after reconnection

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -1,13 +1,19 @@
 //! Unit tests for session module
 
 use deribit_websocket::config::WebSocketConfig;
+use deribit_websocket::model::subscription::SubscriptionManager;
 use deribit_websocket::session::WebSocketSession;
 use std::sync::Arc;
+use tokio::sync::Mutex;
+
+fn make_subscription_manager() -> Arc<Mutex<SubscriptionManager>> {
+    Arc::new(Mutex::new(SubscriptionManager::new()))
+}
 
 #[test]
 fn test_websocket_session_creation() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Test that session can be created
     let debug_str = format!("{:?}", session);
@@ -17,7 +23,7 @@ fn test_websocket_session_creation() {
 #[test]
 fn test_websocket_session_with_production_config() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     let debug_str = format!("{:?}", session);
     assert!(debug_str.contains("WebSocketSession"));
@@ -29,7 +35,7 @@ fn test_websocket_session_with_custom_config() {
         .with_heartbeat_interval(std::time::Duration::from_secs(60))
         .with_max_reconnect_attempts(10);
 
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     let debug_str = format!("{:?}", session);
     assert!(debug_str.contains("WebSocketSession"));
@@ -38,7 +44,7 @@ fn test_websocket_session_with_custom_config() {
 #[test]
 fn test_websocket_session_arc_compatibility() {
     let config = WebSocketConfig::default();
-    let session = Arc::new(WebSocketSession::new(config));
+    let session = Arc::new(WebSocketSession::new(config, make_subscription_manager()));
 
     // Test that session can be wrapped in Arc (for thread safety)
     let session_clone = session.clone();
@@ -53,7 +59,7 @@ fn test_websocket_session_arc_compatibility() {
 #[test]
 fn test_websocket_session_debug_format() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     let debug_output = format!("{:?}", session);
     assert!(debug_output.contains("WebSocketSession"));
@@ -64,7 +70,7 @@ fn test_websocket_session_config_access() {
     let config =
         WebSocketConfig::default().with_heartbeat_interval(std::time::Duration::from_secs(45));
 
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Test that config can be accessed
     let config_ref = session.config();
@@ -74,7 +80,7 @@ fn test_websocket_session_config_access() {
 #[test]
 fn test_websocket_session_subscription_manager() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Test that subscription manager can be accessed
     let manager = session.subscription_manager();
@@ -84,7 +90,7 @@ fn test_websocket_session_subscription_manager() {
 #[tokio::test]
 async fn test_websocket_session_state() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Initial state should be Disconnected
     let state = session.state().await;
@@ -96,7 +102,7 @@ async fn test_websocket_session_set_state() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Set state to Connected
     session.set_state(ConnectionState::Connected).await;
@@ -107,7 +113,7 @@ async fn test_websocket_session_set_state() {
 #[tokio::test]
 async fn test_websocket_session_is_connected_false() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Initial state is Disconnected, so is_connected should be false
     assert!(!session.is_connected().await);
@@ -118,7 +124,7 @@ async fn test_websocket_session_is_connected_true() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     session.set_state(ConnectionState::Connected).await;
     assert!(session.is_connected().await);
@@ -127,7 +133,7 @@ async fn test_websocket_session_is_connected_true() {
 #[tokio::test]
 async fn test_websocket_session_is_authenticated_false() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     assert!(!session.is_authenticated().await);
 }
@@ -137,7 +143,7 @@ async fn test_websocket_session_is_authenticated_true() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     session.set_state(ConnectionState::Authenticated).await;
     assert!(session.is_authenticated().await);
@@ -146,7 +152,7 @@ async fn test_websocket_session_is_authenticated_true() {
 #[tokio::test]
 async fn test_websocket_session_mark_authenticated() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     session.mark_authenticated().await;
     assert!(session.is_authenticated().await);
@@ -157,7 +163,7 @@ async fn test_websocket_session_mark_disconnected() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // First connect and authenticate
     session.set_state(ConnectionState::Authenticated).await;
@@ -172,8 +178,125 @@ async fn test_websocket_session_mark_disconnected() {
 #[tokio::test]
 async fn test_websocket_session_reactivate_subscriptions() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config);
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // This should not panic
     session.reactivate_subscriptions().await;
+}
+
+// Regression tests for #43: client and session must share the same
+// SubscriptionManager so that subscription state stays consistent on
+// reconnect.
+
+#[test]
+fn test_client_and_session_share_subscription_manager() {
+    use deribit_websocket::client::DeribitWebSocketClient;
+
+    let config = WebSocketConfig::default();
+    let client = DeribitWebSocketClient::new(&config).expect("client construction must succeed");
+
+    let client_handle = client.subscription_manager();
+    let session_handle = client.session.subscription_manager();
+
+    assert!(
+        Arc::ptr_eq(&client_handle, &session_handle),
+        "client and session must share the same SubscriptionManager allocation"
+    );
+}
+
+#[tokio::test]
+async fn test_client_mutation_visible_via_session() {
+    use deribit_websocket::client::DeribitWebSocketClient;
+    use deribit_websocket::model::SubscriptionChannel;
+
+    let config = WebSocketConfig::default();
+    let client = DeribitWebSocketClient::new(&config).expect("client construction must succeed");
+
+    {
+        let client_handle = client.subscription_manager();
+        let mut guard = client_handle.lock().await;
+        guard.add_subscription(
+            "ticker.BTC-PERPETUAL.100ms".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+    }
+
+    let session_handle = client.session.subscription_manager();
+    let session_guard = session_handle.lock().await;
+    assert!(
+        session_guard
+            .get_subscription("ticker.BTC-PERPETUAL.100ms")
+            .is_some(),
+        "subscription added via client handle must be visible via session handle"
+    );
+}
+
+#[tokio::test]
+async fn test_session_mark_disconnected_clears_client_view() {
+    use deribit_websocket::client::DeribitWebSocketClient;
+    use deribit_websocket::model::SubscriptionChannel;
+
+    let config = WebSocketConfig::default();
+    let client = DeribitWebSocketClient::new(&config).expect("client construction must succeed");
+
+    {
+        let client_handle = client.subscription_manager();
+        let mut guard = client_handle.lock().await;
+        guard.add_subscription(
+            "ticker.BTC-PERPETUAL.100ms".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+    }
+
+    client.session.mark_disconnected().await;
+
+    let client_handle = client.subscription_manager();
+    let guard = client_handle.lock().await;
+    assert!(
+        guard.get_all_channels().is_empty(),
+        "session.mark_disconnected() must clear the client's view of subscriptions"
+    );
+}
+
+#[tokio::test]
+async fn test_session_reactivate_restores_client_subscriptions() {
+    use deribit_websocket::client::DeribitWebSocketClient;
+    use deribit_websocket::model::SubscriptionChannel;
+
+    let config = WebSocketConfig::default();
+    let client = DeribitWebSocketClient::new(&config).expect("client construction must succeed");
+
+    let channel = "ticker.BTC-PERPETUAL.100ms";
+
+    {
+        let client_handle = client.subscription_manager();
+        let mut guard = client_handle.lock().await;
+        guard.add_subscription(
+            channel.to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+        guard.deactivate_subscription(channel);
+        let sub = guard
+            .get_subscription(channel)
+            .expect("subscription must exist after add_subscription");
+        assert!(
+            !sub.active,
+            "subscription must be inactive after deactivate_subscription"
+        );
+    }
+
+    client.session.reactivate_subscriptions().await;
+
+    let client_handle = client.subscription_manager();
+    let guard = client_handle.lock().await;
+    let sub = guard
+        .get_subscription(channel)
+        .expect("subscription must still exist via client handle after reactivate");
+    assert!(
+        sub.active,
+        "session.reactivate_subscriptions() must restore active=true in the client's view"
+    );
 }

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -233,18 +233,19 @@ async fn test_client_mutation_visible_via_session() {
 }
 
 #[tokio::test]
-async fn test_session_mark_disconnected_clears_client_view() {
+async fn test_session_mark_disconnected_deactivates_client_view() {
     use deribit_websocket::client::DeribitWebSocketClient;
     use deribit_websocket::model::SubscriptionChannel;
 
     let config = WebSocketConfig::default();
     let client = DeribitWebSocketClient::new(&config).expect("client construction must succeed");
+    let channel = "ticker.BTC-PERPETUAL.100ms";
 
     {
         let client_handle = client.subscription_manager();
         let mut guard = client_handle.lock().await;
         guard.add_subscription(
-            "ticker.BTC-PERPETUAL.100ms".to_string(),
+            channel.to_string(),
             SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
             Some("BTC-PERPETUAL".to_string()),
         );
@@ -254,9 +255,45 @@ async fn test_session_mark_disconnected_clears_client_view() {
 
     let client_handle = client.subscription_manager();
     let guard = client_handle.lock().await;
+    let sub = guard
+        .get_subscription(channel)
+        .expect("subscription must remain after mark_disconnected — entry preserved for reconnect");
     assert!(
-        guard.get_all_channels().is_empty(),
-        "session.mark_disconnected() must clear the client's view of subscriptions"
+        !sub.active,
+        "session.mark_disconnected() must mark subscriptions inactive, not remove them"
+    );
+}
+
+#[tokio::test]
+async fn test_disconnect_then_reactivate_restores_active_subscriptions() {
+    use deribit_websocket::client::DeribitWebSocketClient;
+    use deribit_websocket::model::SubscriptionChannel;
+
+    let config = WebSocketConfig::default();
+    let client = DeribitWebSocketClient::new(&config).expect("client construction must succeed");
+    let channel = "ticker.BTC-PERPETUAL.100ms";
+
+    {
+        let client_handle = client.subscription_manager();
+        let mut guard = client_handle.lock().await;
+        guard.add_subscription(
+            channel.to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+    }
+
+    client.session.mark_disconnected().await;
+    client.session.reactivate_subscriptions().await;
+
+    let client_handle = client.subscription_manager();
+    let guard = client_handle.lock().await;
+    let sub = guard
+        .get_subscription(channel)
+        .expect("subscription must survive the disconnect/reactivate cycle");
+    assert!(
+        sub.active,
+        "reactivate_subscriptions() after mark_disconnected() must restore active=true"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #43.

`DeribitWebSocketClient` and `WebSocketSession` each instantiated their own `SubscriptionManager`. The session's instance was never wired back to the client, so:

- `client.subscribe()` mutated the client's set.
- `session.mark_disconnected()` and `session.reactivate_subscriptions()` operated on the session's set.

State diverged silently. Resubscribe-on-reconnect operated on stale state.

Construct the `Arc<Mutex<SubscriptionManager>>` once in `DeribitWebSocketClient::new` and pass the handle into `WebSocketSession::new` so both refer to the same allocation. Add a public `client.subscription_manager()` accessor mirroring the existing `session.subscription_manager()`.

## Breaking change

`WebSocketSession::new` now takes a second argument:

```rust
pub fn new(
    config: WebSocketConfig,
    subscription_manager: Arc<Mutex<SubscriptionManager>>,
) -> Self
```

External callers must construct the `Arc` themselves. Acceptable pre-1.0.

## Verification

`rg 'SubscriptionManager::new\(\)' src/` returns exactly one hit at `src/client.rs:48` — the single allocation site.

## Tests

Four new regression tests in `tests/unit/session.rs`:

1. `test_client_and_session_share_subscription_manager` — `Arc::ptr_eq` proves both handles point at the same allocation.
2. `test_client_mutation_visible_via_session` — `add_subscription` via client handle is visible via session handle.
3. `test_session_mark_disconnected_clears_client_view` — `session.mark_disconnected()` clears the set the client observes.
4. `test_session_reactivate_restores_client_subscriptions` — `session.reactivate_subscriptions()` restores `active=true` for entries the client added.

The 16 existing `tests/unit/session.rs` call sites were updated to pass a fresh `Arc<Mutex<SubscriptionManager>>` via a small `make_subscription_manager()` helper. Test semantics preserved.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --workspace` — 36 + 411 + 5 = 452 passed, 0 failed
- [x] `cargo build --release`
- [x] Architect review — boundaries clean, no `doc/` or `prelude.rs` change needed