### PR TITLE
refactor(message): propagate serde_json errors via WebSocketError::Serialization (#46)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Lint (strict — ban unwrap/expect in lib and tests)
+        run: make lint-strict

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ fmt-check:
 lint:
 	cargo clippy --all-targets --all-features -- -D warnings
 
+# Strict lints for the library + test targets only. Examples and benches are
+# intentionally excluded so illustrative code can still use `.unwrap()`.
+.PHONY: lint-strict
+lint-strict:
+	cargo clippy --lib --tests --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used
+
 .PHONY: lint-fix
 lint-fix: 
 	cargo clippy --fix --all-targets --all-features --allow-dirty --allow-staged -- -D warnings
@@ -48,7 +54,7 @@ clean:
 
 # Pre-push checks
 .PHONY: check
-check: test fmt-check lint
+check: test fmt-check lint lint-strict
 
 # Run the project
 .PHONY: run

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -117,6 +117,7 @@ impl MessageHandlerBuilder {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -646,7 +646,7 @@ impl DeribitWebSocketClient {
 
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_mass_quote_request(request)
+            builder.build_mass_quote_request(request)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -672,7 +672,7 @@ impl DeribitWebSocketClient {
     ) -> Result<CancelQuotesResponse, WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_cancel_quotes_request(request)
+            builder.build_cancel_quotes_request(request)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -792,7 +792,7 @@ impl DeribitWebSocketClient {
     ) -> Result<crate::model::trading::OrderResponse, WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_buy_request(&request)
+            builder.build_buy_request(&request)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -822,7 +822,7 @@ impl DeribitWebSocketClient {
     ) -> Result<crate::model::trading::OrderResponse, WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_sell_request(&request)
+            builder.build_sell_request(&request)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -971,7 +971,7 @@ impl DeribitWebSocketClient {
     ) -> Result<crate::model::trading::OrderResponse, WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_edit_request(&request)
+            builder.build_edit_request(&request)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -1176,7 +1176,7 @@ impl DeribitWebSocketClient {
     ) -> Result<crate::model::ClosePositionResponse, WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_close_position_request(instrument_name, order_type, price)
+            builder.build_close_position_request(instrument_name, order_type, price)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -1221,7 +1221,7 @@ impl DeribitWebSocketClient {
     ) -> Result<Vec<crate::model::MovePositionResult>, WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_move_positions_request(currency, source_uid, target_uid, trades)
+            builder.build_move_positions_request(currency, source_uid, target_uid, trades)?
         };
 
         let response = self.send_request(json_request).await?;
@@ -1353,6 +1353,10 @@ impl DeribitWebSocketClient {
 impl Default for DeribitWebSocketClient {
     fn default() -> Self {
         let config = WebSocketConfig::default();
+        // `Default` cannot return `Result`; `Self::new` only fails on invalid
+        // URL parsing which cannot happen for `WebSocketConfig::default()`.
+        // Tracked separately for a fallible-only constructor redesign.
+        #[allow(clippy::unwrap_used)]
         Self::new(&config).unwrap()
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -695,7 +695,7 @@ impl DeribitWebSocketClient {
     pub async fn set_mmp_config(&self, config: MmpGroupConfig) -> Result<(), WebSocketError> {
         let json_request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_set_mmp_config_request(config)
+            builder.build_set_mmp_config_request(config)?
         };
 
         let response = self.send_request(json_request).await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,9 @@ impl Default for WebSocketConfig {
             .unwrap_or(64);
 
         Self {
+            // TODO(#48): Replace Default with a fallible constructor so this
+            // hard-coded fallback URL does not rely on an `.unwrap()`.
+            #[allow(clippy::unwrap_used)]
             ws_url: Url::parse(&ws_url)
                 .unwrap_or_else(|_| Url::parse("wss://www.deribit.com/ws/api/v2").unwrap()),
             heartbeat_interval,

--- a/src/connection/dispatcher.rs
+++ b/src/connection/dispatcher.rs
@@ -327,6 +327,7 @@ async fn run_dispatcher(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use futures_util::{SinkExt, StreamExt};

--- a/src/connection/ws_connection.rs
+++ b/src/connection/ws_connection.rs
@@ -106,6 +106,7 @@ impl WebSocketConnection {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use futures_util::{SinkExt, StreamExt};

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -39,4 +39,12 @@ pub enum WebSocketError {
     /// The background dispatcher task is not running (never started, shut
     /// down, or panicked). No further I/O can be performed through it.
     DispatcherDead,
+
+    #[error("Serialization error: {0}")]
+    /// JSON serialization or deserialization failed.
+    ///
+    /// Typically raised when a request contains a numeric field whose value
+    /// cannot be represented in JSON (e.g. `NaN` or `Infinity` in an `f64`),
+    /// or when parsing a malformed response payload.
+    Serialization(#[from] serde_json::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,9 @@
 // Regression guard against future `std::sync::Mutex` use across `.await`.
 // Tokio's mutex (which this crate uses) is intentionally allowed.
 #![warn(clippy::await_holding_lock)]
+// Ban `.unwrap()`/`.expect()` in library code. `#[cfg(test)]` modules inside
+// `src/` keep the default behaviour so existing unit tests continue to work.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod callback;
 pub mod client;

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -1,6 +1,40 @@
 //! WebSocket request message handling
 
+use serde::ser::Error as _;
+
+use crate::error::WebSocketError;
 use crate::model::{quote::*, trading::*, ws_types::JsonRpcRequest};
+
+/// Build a [`WebSocketError::Serialization`] carrying `msg` as the underlying
+/// `serde_json::Error`. Used to surface non-finite-float rejections the same
+/// way a real JSON serialization failure would surface.
+#[cold]
+#[inline(never)]
+fn serialization_error(msg: impl std::fmt::Display) -> WebSocketError {
+    WebSocketError::Serialization(serde_json::Error::custom(msg))
+}
+
+/// Reject `NaN` and `+/- Infinity`. `serde_json` silently maps these to
+/// `null` when serializing — which would otherwise corrupt outgoing requests.
+#[inline]
+fn check_finite(field: &'static str, value: f64) -> Result<(), WebSocketError> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(serialization_error(format_args!(
+            "field `{field}` must be finite, got {value}"
+        )))
+    }
+}
+
+/// Same as [`check_finite`] for optional values. `None` is always accepted.
+#[inline]
+fn check_finite_opt(field: &'static str, value: Option<f64>) -> Result<(), WebSocketError> {
+    match value {
+        Some(v) => check_finite(field, v),
+        None => Ok(()),
+    }
+}
 
 /// Request builder for WebSocket messages
 #[derive(Debug, Clone)]
@@ -213,18 +247,41 @@ impl RequestBuilder {
     }
 
     /// Build mass quote request
-    pub fn build_mass_quote_request(&mut self, request: MassQuoteRequest) -> JsonRpcRequest {
-        let params = serde_json::to_value(request).expect("Failed to serialize mass quote request");
-
-        self.build_request("private/mass_quote", Some(params))
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if the request contains values
+    /// that cannot be represented in JSON (for example `NaN` or `Infinity` in
+    /// any `f64` field such as `price` or `amount`).
+    pub fn build_mass_quote_request(
+        &mut self,
+        request: MassQuoteRequest,
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        for quote in &request.quotes {
+            check_finite("quotes[].amount", quote.amount)?;
+            check_finite("quotes[].price", quote.price)?;
+        }
+        let params = serde_json::to_value(request)?;
+        Ok(self.build_request("private/mass_quote", Some(params)))
     }
 
     /// Build cancel quotes request
-    pub fn build_cancel_quotes_request(&mut self, request: CancelQuotesRequest) -> JsonRpcRequest {
-        let params =
-            serde_json::to_value(request).expect("Failed to serialize cancel quotes request");
-
-        self.build_request("private/cancel_quotes", Some(params))
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if the request contains values
+    /// that cannot be represented in JSON (for example `NaN` or `Infinity` in
+    /// the `delta_range` tuple).
+    pub fn build_cancel_quotes_request(
+        &mut self,
+        request: CancelQuotesRequest,
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        if let Some((min, max)) = request.delta_range {
+            check_finite("delta_range.min", min)?;
+            check_finite("delta_range.max", max)?;
+        }
+        let params = serde_json::to_value(request)?;
+        Ok(self.build_request("private/cancel_quotes", Some(params)))
     }
 
     /// Build set MMP config request
@@ -294,121 +351,41 @@ impl RequestBuilder {
     }
 
     /// Build buy order request
-    pub fn build_buy_request(&mut self, request: &OrderRequest) -> JsonRpcRequest {
-        let mut params = serde_json::json!({
-            "instrument_name": request.instrument_name,
-            "amount": request.amount
-        });
-
-        if let Some(ref order_type) = request.order_type {
-            params["type"] = serde_json::Value::String(order_type.as_str().to_string());
-        }
-        if let Some(price) = request.price {
-            params["price"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(price).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(ref label) = request.label {
-            params["label"] = serde_json::Value::String(label.clone());
-        }
-        if let Some(ref tif) = request.time_in_force {
-            params["time_in_force"] = serde_json::Value::String(tif.as_str().to_string());
-        }
-        if let Some(max_show) = request.max_show {
-            params["max_show"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(max_show).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(post_only) = request.post_only {
-            params["post_only"] = serde_json::Value::Bool(post_only);
-        }
-        if let Some(reduce_only) = request.reduce_only {
-            params["reduce_only"] = serde_json::Value::Bool(reduce_only);
-        }
-        if let Some(trigger_price) = request.trigger_price {
-            params["trigger_price"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(trigger_price).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(ref trigger) = request.trigger {
-            let trigger_str = match trigger {
-                Trigger::IndexPrice => "index_price",
-                Trigger::MarkPrice => "mark_price",
-                Trigger::LastPrice => "last_price",
-            };
-            params["trigger"] = serde_json::Value::String(trigger_str.to_string());
-        }
-        if let Some(ref advanced) = request.advanced {
-            params["advanced"] = serde_json::Value::String(advanced.clone());
-        }
-        if let Some(mmp) = request.mmp {
-            params["mmp"] = serde_json::Value::Bool(mmp);
-        }
-        if let Some(valid_until) = request.valid_until {
-            params["valid_until"] =
-                serde_json::Value::Number(serde_json::Number::from(valid_until));
-        }
-
-        self.build_request("private/buy", Some(params))
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if `request` contains values
+    /// that cannot be represented in JSON (for example `NaN` or `Infinity` in
+    /// `price`, `amount`, `max_show` or `trigger_price`).
+    pub fn build_buy_request(
+        &mut self,
+        request: &OrderRequest,
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        check_finite("amount", request.amount)?;
+        check_finite_opt("price", request.price)?;
+        check_finite_opt("max_show", request.max_show)?;
+        check_finite_opt("trigger_price", request.trigger_price)?;
+        let params = serde_json::to_value(request)?;
+        Ok(self.build_request("private/buy", Some(params)))
     }
 
     /// Build sell order request
-    pub fn build_sell_request(&mut self, request: &OrderRequest) -> JsonRpcRequest {
-        let mut params = serde_json::json!({
-            "instrument_name": request.instrument_name,
-            "amount": request.amount
-        });
-
-        if let Some(ref order_type) = request.order_type {
-            params["type"] = serde_json::Value::String(order_type.as_str().to_string());
-        }
-        if let Some(price) = request.price {
-            params["price"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(price).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(ref label) = request.label {
-            params["label"] = serde_json::Value::String(label.clone());
-        }
-        if let Some(ref tif) = request.time_in_force {
-            params["time_in_force"] = serde_json::Value::String(tif.as_str().to_string());
-        }
-        if let Some(max_show) = request.max_show {
-            params["max_show"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(max_show).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(post_only) = request.post_only {
-            params["post_only"] = serde_json::Value::Bool(post_only);
-        }
-        if let Some(reduce_only) = request.reduce_only {
-            params["reduce_only"] = serde_json::Value::Bool(reduce_only);
-        }
-        if let Some(trigger_price) = request.trigger_price {
-            params["trigger_price"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(trigger_price).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(ref trigger) = request.trigger {
-            let trigger_str = match trigger {
-                Trigger::IndexPrice => "index_price",
-                Trigger::MarkPrice => "mark_price",
-                Trigger::LastPrice => "last_price",
-            };
-            params["trigger"] = serde_json::Value::String(trigger_str.to_string());
-        }
-        if let Some(ref advanced) = request.advanced {
-            params["advanced"] = serde_json::Value::String(advanced.clone());
-        }
-        if let Some(mmp) = request.mmp {
-            params["mmp"] = serde_json::Value::Bool(mmp);
-        }
-        if let Some(valid_until) = request.valid_until {
-            params["valid_until"] =
-                serde_json::Value::Number(serde_json::Number::from(valid_until));
-        }
-
-        self.build_request("private/sell", Some(params))
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if `request` contains values
+    /// that cannot be represented in JSON (for example `NaN` or `Infinity` in
+    /// `price`, `amount`, `max_show` or `trigger_price`).
+    pub fn build_sell_request(
+        &mut self,
+        request: &OrderRequest,
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        check_finite("amount", request.amount)?;
+        check_finite_opt("price", request.price)?;
+        check_finite_opt("max_show", request.max_show)?;
+        check_finite_opt("trigger_price", request.trigger_price)?;
+        let params = serde_json::to_value(request)?;
+        Ok(self.build_request("private/sell", Some(params)))
     }
 
     /// Build cancel order request
@@ -447,40 +424,21 @@ impl RequestBuilder {
     }
 
     /// Build edit order request
-    pub fn build_edit_request(&mut self, request: &EditOrderRequest) -> JsonRpcRequest {
-        let mut params = serde_json::json!({
-            "order_id": request.order_id,
-            "amount": request.amount
-        });
-
-        if let Some(price) = request.price {
-            params["price"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(price).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(post_only) = request.post_only {
-            params["post_only"] = serde_json::Value::Bool(post_only);
-        }
-        if let Some(reduce_only) = request.reduce_only {
-            params["reduce_only"] = serde_json::Value::Bool(reduce_only);
-        }
-        if let Some(ref advanced) = request.advanced {
-            params["advanced"] = serde_json::Value::String(advanced.clone());
-        }
-        if let Some(trigger_price) = request.trigger_price {
-            params["trigger_price"] = serde_json::Value::Number(
-                serde_json::Number::from_f64(trigger_price).unwrap_or(serde_json::Number::from(0)),
-            );
-        }
-        if let Some(mmp) = request.mmp {
-            params["mmp"] = serde_json::Value::Bool(mmp);
-        }
-        if let Some(valid_until) = request.valid_until {
-            params["valid_until"] =
-                serde_json::Value::Number(serde_json::Number::from(valid_until));
-        }
-
-        self.build_request("private/edit", Some(params))
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if `request` contains values
+    /// that cannot be represented in JSON (for example `NaN` or `Infinity` in
+    /// `price`, `amount` or `trigger_price`).
+    pub fn build_edit_request(
+        &mut self,
+        request: &EditOrderRequest,
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        check_finite("amount", request.amount)?;
+        check_finite_opt("price", request.price)?;
+        check_finite_opt("trigger_price", request.trigger_price)?;
+        let params = serde_json::to_value(request)?;
+        Ok(self.build_request("private/edit", Some(params)))
     }
 
     // Account methods
@@ -633,12 +591,17 @@ impl RequestBuilder {
     /// # Returns
     ///
     /// A JSON-RPC request for closing a position
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if `price` is `NaN` or
+    /// `Infinity`, which cannot be represented in JSON.
     pub fn build_close_position_request(
         &mut self,
         instrument_name: &str,
         order_type: &str,
         price: Option<f64>,
-    ) -> JsonRpcRequest {
+    ) -> Result<JsonRpcRequest, WebSocketError> {
         let mut params = serde_json::Map::new();
         params.insert(
             "instrument_name".to_string(),
@@ -649,16 +612,15 @@ impl RequestBuilder {
             serde_json::Value::String(order_type.to_string()),
         );
 
-        if let Some(price) = price
-            && let Some(price_num) = serde_json::Number::from_f64(price)
-        {
-            params.insert("price".to_string(), serde_json::Value::Number(price_num));
+        if let Some(price) = price {
+            check_finite("price", price)?;
+            params.insert("price".to_string(), serde_json::to_value(price)?);
         }
 
-        self.build_request(
+        Ok(self.build_request(
             crate::constants::methods::PRIVATE_CLOSE_POSITION,
             Some(serde_json::Value::Object(params)),
-        )
+        ))
     }
 
     /// Build a move_positions request
@@ -673,32 +635,24 @@ impl RequestBuilder {
     /// # Returns
     ///
     /// A JSON-RPC request for moving positions between subaccounts
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if any `amount` or `price`
+    /// value in `trades` is `NaN` or `Infinity`, which cannot be represented
+    /// in JSON.
     pub fn build_move_positions_request(
         &mut self,
         currency: &str,
         source_uid: u64,
         target_uid: u64,
         trades: &[crate::model::MovePositionTrade],
-    ) -> JsonRpcRequest {
-        let trades_json: Vec<serde_json::Value> = trades
-            .iter()
-            .map(|t| {
-                let mut trade_obj = serde_json::Map::new();
-                trade_obj.insert(
-                    "instrument_name".to_string(),
-                    serde_json::Value::String(t.instrument_name.clone()),
-                );
-                if let Some(amount_num) = serde_json::Number::from_f64(t.amount) {
-                    trade_obj.insert("amount".to_string(), serde_json::Value::Number(amount_num));
-                }
-                if let Some(price) = t.price
-                    && let Some(price_num) = serde_json::Number::from_f64(price)
-                {
-                    trade_obj.insert("price".to_string(), serde_json::Value::Number(price_num));
-                }
-                serde_json::Value::Object(trade_obj)
-            })
-            .collect();
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        for trade in trades {
+            check_finite("trades[_].amount", trade.amount)?;
+            check_finite_opt("trades[_].price", trade.price)?;
+        }
+        let trades_json = serde_json::to_value(trades)?;
 
         let params = serde_json::json!({
             "currency": currency,
@@ -707,9 +661,9 @@ impl RequestBuilder {
             "trades": trades_json
         });
 
-        self.build_request(
+        Ok(self.build_request(
             crate::constants::methods::PRIVATE_MOVE_POSITIONS,
             Some(params),
-        )
+        ))
     }
 }

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -285,7 +285,21 @@ impl RequestBuilder {
     }
 
     /// Build set MMP config request
-    pub fn build_set_mmp_config_request(&mut self, config: MmpGroupConfig) -> JsonRpcRequest {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::Serialization`] if `config.quantity_limit` or
+    /// `config.delta_limit` is `NaN` or `Infinity`. `MmpGroupConfig::new`
+    /// enforces magnitude invariants but NaN comparisons always return false
+    /// and silently bypass them, which is why the finite check is repeated
+    /// here.
+    pub fn build_set_mmp_config_request(
+        &mut self,
+        config: MmpGroupConfig,
+    ) -> Result<JsonRpcRequest, WebSocketError> {
+        check_finite("quantity_limit", config.quantity_limit)?;
+        check_finite("delta_limit", config.delta_limit)?;
+
         let mut params = serde_json::json!({
             "mmp_group": config.mmp_group,
             "quantity_limit": config.quantity_limit,
@@ -299,7 +313,7 @@ impl RequestBuilder {
             params["interval"] = serde_json::Value::Number(serde_json::Number::from(0));
         }
 
-        self.build_request("private/set_mmp_config", Some(params))
+        Ok(self.build_request("private/set_mmp_config", Some(params)))
     }
 
     /// Build get MMP config request

--- a/src/model/account.rs
+++ b/src/model/account.rs
@@ -241,6 +241,7 @@ pub struct AccountSummary {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/model/position.rs
+++ b/src/model/position.rs
@@ -200,6 +200,7 @@ pub struct MovePositionResult {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/model/quote.rs
+++ b/src/model/quote.rs
@@ -390,6 +390,7 @@ impl MmpGroupConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/model/trading.rs
+++ b/src/model/trading.rs
@@ -424,6 +424,7 @@ pub struct OrderResponse {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -56,6 +56,7 @@ pub fn setup_logger() {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,10 @@
 //! Integration tests for deribit-websocket crate
 
+// Integration tests routinely use `.unwrap()` / `.expect()` for brevity and
+// to surface failures with clear panic messages. Silence the strict lints
+// that are enforced on the library crate here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 mod integration;
 mod unit;
 

--- a/tests/unit/error.rs
+++ b/tests/unit/error.rs
@@ -43,6 +43,9 @@ fn test_websocket_error_source() {
 
 #[test]
 fn test_websocket_error_variants() {
+    // Build an invalid JSON payload to get a real `serde_json::Error`.
+    let serde_err = serde_json::from_str::<serde_json::Value>("{ not json }").unwrap_err();
+
     // Test all error variants exist and can be created
     let errors = [
         WebSocketError::ConnectionFailed("test".to_string()),
@@ -51,9 +54,35 @@ fn test_websocket_error_variants() {
         WebSocketError::SubscriptionFailed("test".to_string()),
         WebSocketError::ConnectionClosed,
         WebSocketError::HeartbeatTimeout,
+        WebSocketError::Serialization(serde_err),
     ];
 
-    assert_eq!(errors.len(), 6);
+    assert_eq!(errors.len(), 7);
+}
+
+#[test]
+fn test_websocket_error_serialization_from_serde_json_error() {
+    // `?` propagation from `serde_json::to_value(...)` relies on this `From`
+    // impl being wired up by `#[from]`.
+    let serde_err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+    let err: WebSocketError = serde_err.into();
+
+    assert!(matches!(err, WebSocketError::Serialization(_)));
+    assert!(err.to_string().starts_with("Serialization error:"));
+    assert!(err.source().is_some());
+}
+
+#[test]
+fn test_websocket_error_serialization_display_includes_inner_message() {
+    let serde_err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+    let inner_message = serde_err.to_string();
+    let err: WebSocketError = serde_err.into();
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains(&inner_message),
+        "outer display should embed the inner serde_json error; got {rendered:?}"
+    );
 }
 
 #[test]

--- a/tests/unit/message.rs
+++ b/tests/unit/message.rs
@@ -521,7 +521,8 @@ fn test_test_response_equality() {
 
 use deribit_websocket::error::WebSocketError;
 use deribit_websocket::model::{
-    CancelQuotesRequest, EditOrderRequest, MassQuoteRequest, MovePositionTrade, OrderRequest, Quote,
+    CancelQuotesRequest, EditOrderRequest, MassQuoteRequest, MmpGroupConfig, MovePositionTrade,
+    OrderRequest, Quote,
 };
 
 #[test]
@@ -661,5 +662,48 @@ fn test_build_move_positions_request_nan_amount_returns_serialization_error() {
     assert!(
         matches!(result, Err(WebSocketError::Serialization(_))),
         "NaN move_positions amount must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_set_mmp_config_request_nan_quantity_limit_returns_serialization_error() {
+    // `MmpGroupConfig::new` compares magnitudes with `>=` and `>`, both of
+    // which return false for NaN. That lets NaN slip past validation and into
+    // the wire format as a silent `null`. The builder must catch it.
+    let mut builder = RequestBuilder::new();
+    let config = MmpGroupConfig {
+        mmp_group: "btc_mm".to_string(),
+        quantity_limit: f64::NAN,
+        delta_limit: 1.0,
+        interval: 1_000,
+        frozen_time: 5_000,
+        enabled: true,
+    };
+
+    let result = builder.build_set_mmp_config_request(config);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN quantity_limit must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_set_mmp_config_request_infinity_delta_limit_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let config = MmpGroupConfig {
+        mmp_group: "btc_mm".to_string(),
+        quantity_limit: 10.0,
+        delta_limit: f64::INFINITY,
+        interval: 1_000,
+        frozen_time: 5_000,
+        enabled: true,
+    };
+
+    let result = builder.build_set_mmp_config_request(config);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "Infinity delta_limit must propagate as Serialization error, got {result:?}"
     );
 }

--- a/tests/unit/message.rs
+++ b/tests/unit/message.rs
@@ -510,3 +510,156 @@ fn test_test_response_equality() {
     assert_eq!(response1, response2);
     assert_ne!(response1, response3);
 }
+
+// =============================================================================
+// Serialization error propagation tests (Issue #46)
+//
+// Every request builder that accepts untrusted `f64` input must surface a
+// `WebSocketError::Serialization` instead of panicking when the input cannot
+// be encoded as JSON (NaN / Infinity). These tests lock in that contract.
+// =============================================================================
+
+use deribit_websocket::error::WebSocketError;
+use deribit_websocket::model::{
+    CancelQuotesRequest, EditOrderRequest, MassQuoteRequest, MovePositionTrade, OrderRequest, Quote,
+};
+
+#[test]
+fn test_build_mass_quote_request_nan_price_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let quotes = vec![Quote::buy("BTC-PERPETUAL".to_string(), 1.0, f64::NAN)];
+    let request = MassQuoteRequest::new("btc_group".to_string(), quotes);
+
+    let result = builder.build_mass_quote_request(request);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN price must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_mass_quote_request_infinity_amount_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let quotes = vec![Quote::buy(
+        "BTC-PERPETUAL".to_string(),
+        f64::INFINITY,
+        50_000.0,
+    )];
+    let request = MassQuoteRequest::new("btc_group".to_string(), quotes);
+
+    let result = builder.build_mass_quote_request(request);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "Infinity amount must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_mass_quote_request_happy_path_returns_ok() {
+    let mut builder = RequestBuilder::new();
+    let quotes = vec![
+        Quote::buy("BTC-PERPETUAL".to_string(), 1.0, 50_000.0),
+        Quote::sell("BTC-PERPETUAL".to_string(), 1.0, 51_000.0),
+    ];
+    let request = MassQuoteRequest::new("btc_group".to_string(), quotes);
+
+    let rpc = builder
+        .build_mass_quote_request(request)
+        .expect("valid request should build successfully");
+
+    assert_eq!(rpc.method, "private/mass_quote");
+    assert_eq!(rpc.jsonrpc, "2.0");
+    assert!(rpc.params.is_some());
+}
+
+#[test]
+fn test_build_cancel_quotes_request_nan_delta_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let request = CancelQuotesRequest::by_delta_range(f64::NAN, 1.0);
+
+    let result = builder.build_cancel_quotes_request(request);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN delta must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_buy_request_nan_price_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 1.0, f64::NAN);
+
+    let result = builder.build_buy_request(&request);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN price must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_sell_request_infinity_max_show_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 1.0, 50_000.0)
+        .with_max_show(f64::INFINITY);
+
+    let result = builder.build_sell_request(&request);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "Infinity max_show must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_edit_request_nan_trigger_price_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    // `EditOrderRequest` only exposes a `with_price` builder, so construct via
+    // struct literal to place the NaN on the intended field.
+    let request = EditOrderRequest {
+        order_id: "order-1".to_string(),
+        amount: 1.0,
+        price: Some(50_000.0),
+        post_only: None,
+        reduce_only: None,
+        advanced: None,
+        trigger_price: Some(f64::NAN),
+        mmp: None,
+        valid_until: None,
+    };
+
+    let result = builder.build_edit_request(&request);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN trigger_price must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_close_position_request_nan_price_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+
+    let result = builder.build_close_position_request("BTC-PERPETUAL", "limit", Some(f64::NAN));
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN close_position price must propagate as Serialization error, got {result:?}"
+    );
+}
+
+#[test]
+fn test_build_move_positions_request_nan_amount_returns_serialization_error() {
+    let mut builder = RequestBuilder::new();
+    let trades = vec![MovePositionTrade::new("BTC-PERPETUAL", f64::NAN)];
+
+    let result = builder.build_move_positions_request("BTC", 1, 2, &trades);
+
+    assert!(
+        matches!(result, Err(WebSocketError::Serialization(_))),
+        "NaN move_positions amount must propagate as Serialization error, got {result:?}"
+    );
+}

--- a/tests/unit/position.rs
+++ b/tests/unit/position.rs
@@ -261,7 +261,9 @@ fn test_close_order_with_optional_fields() {
 #[test]
 fn test_request_builder_close_position_market() {
     let mut builder = RequestBuilder::new();
-    let request = builder.build_close_position_request("BTC-PERPETUAL", "market", None);
+    let request = builder
+        .build_close_position_request("BTC-PERPETUAL", "market", None)
+        .expect("build request");
 
     assert_eq!(request.method, "private/close_position");
     assert!(request.params.is_some());
@@ -275,7 +277,9 @@ fn test_request_builder_close_position_market() {
 #[test]
 fn test_request_builder_close_position_limit() {
     let mut builder = RequestBuilder::new();
-    let request = builder.build_close_position_request("ETH-PERPETUAL", "limit", Some(3000.0));
+    let request = builder
+        .build_close_position_request("ETH-PERPETUAL", "limit", Some(3000.0))
+        .expect("build request");
 
     assert_eq!(request.method, "private/close_position");
     assert!(request.params.is_some());
@@ -293,7 +297,9 @@ fn test_request_builder_move_positions() {
         MovePositionTrade::new("BTC-PERPETUAL", 100.0).with_price(50000.0),
         MovePositionTrade::new("ETH-PERPETUAL", 50.0),
     ];
-    let request = builder.build_move_positions_request("BTC", 3, 23, &trades);
+    let request = builder
+        .build_move_positions_request("BTC", 3, 23, &trades)
+        .expect("build request");
 
     assert_eq!(request.method, "private/move_positions");
     assert!(request.params.is_some());
@@ -311,7 +317,9 @@ fn test_request_builder_move_positions() {
 fn test_request_builder_move_positions_single() {
     let mut builder = RequestBuilder::new();
     let trades = vec![MovePositionTrade::new("BTC-PERPETUAL", 110.0).with_price(35800.0)];
-    let request = builder.build_move_positions_request("BTC", 5, 10, &trades);
+    let request = builder
+        .build_move_positions_request("BTC", 5, 10, &trades)
+        .expect("build request");
 
     assert_eq!(request.method, "private/move_positions");
     let params = request.params.expect("params");
@@ -323,8 +331,12 @@ fn test_request_builder_move_positions_single() {
 fn test_request_builder_incremental_ids() {
     let mut builder = RequestBuilder::new();
 
-    let r1 = builder.build_close_position_request("BTC-PERPETUAL", "market", None);
-    let r2 = builder.build_close_position_request("ETH-PERPETUAL", "limit", Some(3000.0));
+    let r1 = builder
+        .build_close_position_request("BTC-PERPETUAL", "market", None)
+        .expect("build request 1");
+    let r2 = builder
+        .build_close_position_request("ETH-PERPETUAL", "limit", Some(3000.0))
+        .expect("build request 2");
 
     assert_eq!(r1.id, serde_json::json!(1));
     assert_eq!(r2.id, serde_json::json!(2));

--- a/tests/unit/trading.rs
+++ b/tests/unit/trading.rs
@@ -355,7 +355,9 @@ fn test_trade_execution_deserialization() {
 fn test_request_builder_buy() {
     let mut builder = RequestBuilder::new();
     let order_request = OrderRequest::limit("BTC-PERPETUAL".to_string(), 100.0, 50000.0);
-    let request = builder.build_buy_request(&order_request);
+    let request = builder
+        .build_buy_request(&order_request)
+        .expect("build request");
 
     assert_eq!(request.method, "private/buy");
     assert!(request.params.is_some());
@@ -369,7 +371,9 @@ fn test_request_builder_buy() {
 fn test_request_builder_sell() {
     let mut builder = RequestBuilder::new();
     let order_request = OrderRequest::limit("ETH-PERPETUAL".to_string(), 10.0, 3000.0);
-    let request = builder.build_sell_request(&order_request);
+    let request = builder
+        .build_sell_request(&order_request)
+        .expect("build request");
 
     assert_eq!(request.method, "private/sell");
     assert!(request.params.is_some());
@@ -427,7 +431,9 @@ fn test_request_builder_cancel_all_by_instrument() {
 fn test_request_builder_edit() {
     let mut builder = RequestBuilder::new();
     let edit_request = EditOrderRequest::new("order123".to_string(), 200.0).with_price(51000.0);
-    let request = builder.build_edit_request(&edit_request);
+    let request = builder
+        .build_edit_request(&edit_request)
+        .expect("build request");
 
     assert_eq!(request.method, "private/edit");
     assert!(request.params.is_some());


### PR DESCRIPTION
## Summary

Replaces every `.expect()` and `Number::from_f64(...).unwrap_or(0)` silent coercion in `src/message/request.rs` with proper `Result`-based error propagation through a new `WebSocketError::Serialization(serde_json::Error)` variant. Malformed caller input — `NaN`, `Infinity`, or any value that cannot be encoded as JSON — now surfaces as `WebSocketError::Serialization` instead of panicking the client or silently writing `null`/`0` on the wire. CI is tightened to keep it that way.

## Changes

- **Error type**: add `WebSocketError::Serialization(#[from] serde_json::Error)` for zero-cost `?` propagation from any `serde_json::Error`.
- **Request builders** — 7 `RequestBuilder` methods now return `Result<JsonRpcRequest, WebSocketError>` instead of `JsonRpcRequest`:
  - `build_mass_quote_request`, `build_cancel_quotes_request`
  - `build_buy_request`, `build_sell_request`, `build_edit_request`
  - `build_close_position_request`, `build_move_positions_request`
- **Finite-float validation**: private `check_finite` / `check_finite_opt` helpers. `serde_json` silently encodes `NaN`/`Infinity` as JSON `null`, so an explicit pre-check is required to honour the `Serialization` contract.
- **Simplification**: hand-built `serde_json::Map` construction in buy/sell/edit replaced by `serde_json::to_value(&struct)?` — wire format stays identical thanks to the existing `#[serde(rename*)]` attributes on `OrderRequest` / `EditOrderRequest` / `Trigger`.
- **Call-site propagation**: `?` threaded through all 7 call sites in `src/client.rs`.
- **CI enforcement**:
  - Crate-level `#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]` in `src/lib.rs`.
  - New `make lint-strict` target (`cargo clippy --lib --tests --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`) wired into `.github/workflows/lint.yml` and `make check`.
  - Targeted `#[allow(clippy::unwrap_used)]` on two out-of-scope sites: `config.rs:119` (tracked by #48) and `client.rs` `Default` impl.
  - `#[allow(clippy::unwrap_used, clippy::expect_used)]` on in-src `#[cfg(test)] mod tests` blocks and on `tests/lib.rs`.
- **Tests** (11 new):
  - 9 new tests in `tests/unit/message.rs` covering `NaN`/`Infinity` rejection on every builder plus a happy-path regression guard. All use `matches!(..., Err(WebSocketError::Serialization(_)))`.
  - 2 new tests in `tests/unit/error.rs` covering `From<serde_json::Error>`, `Display` forwarding, and `Error::source` wiring.
  - Existing `tests/unit/position.rs` and `tests/unit/trading.rs` builder tests updated to unwrap the new `Result`.

## Technical Decisions

- **Explicit finite-float validation over custom serializer.** `serde_json`'s default serializers silently map `NaN`/`Infinity` to `null` — neither `to_value` nor `to_string` errors on them. A custom serializer would be reusable but is overkill; per-field `check_finite` is simple, readable, and produces clear error messages (`"field \`quotes[].price\` must be finite, got NaN"`).
- **`#![cfg_attr(not(test), deny(...))]` at crate root** is the narrowest enforcement: library code is denied at compile time, in-file `#[cfg(test)]` modules keep their existing panic style, and the deny does not leak to dependent crates (examples stay clean).
- **Out-of-scope `.unwrap()` sites** (`config.rs` `Url::parse` fallback, `client.rs` `Default` impl) get a targeted `#[allow(clippy::unwrap_used)]` with a TODO referencing issue #48 rather than silencing the lint globally. This surfaces them as explicit follow-up rather than hiding them.
- **Append-only PR scope.** The issue listed "30+ unwrap/expect calls"; the actual survey found 2 hard `.expect()` + 8 `.unwrap_or(0)` NaN-coercions. Scope expanded (with user approval) to cover the `unwrap_or` patterns too, since they are the same class of bug.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — integration tests require live Deribit credentials and are gated behind the `integration-tests` feature)
- [ ] Benchmark tests added/updated (not applicable)
- [x] Manual testing performed (`cargo test --all-features`)

Test summary: **423 unit + lib + doc tests pass, 0 failed**. The 22 feature-gated integration tests are unaffected (they require live Deribit API credentials and are not part of default CI).

## Checklist

- [x] All public items have `///` documentation (added `# Errors` sections to every changed builder)
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] No warnings from `cargo clippy --lib --tests --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code (the two remaining out-of-scope sites carry targeted `#[allow]` with TODOs)
- [x] `cargo build --release --all-features` clean
- [x] WebSocket connection lifecycle handled
- [x] Minimal dependencies — no new crates added

Acceptance grep (from the issue):

```
$ rg 'unwrap\(\)|expect\(' src/message/ src/model/
src/model/position.rs:…  #[cfg(test)] only
src/model/account.rs:…   #[cfg(test)] only
src/model/trading.rs:…   #[cfg(test)] only
```

`src/message/` is clean; `src/model/` matches are all inside `#[cfg(test)] mod tests` blocks.

Closes #46
