### PR TITLE
refactor(config): add try_new fallible constructor, remove .unwrap() fallback (#48)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,8 @@ use std::env;
 use std::time::Duration;
 use url::Url;
 
+use crate::constants;
+
 /// WebSocket client configuration
 #[derive(Debug, Clone)]
 pub struct WebSocketConfig {
@@ -50,15 +52,73 @@ pub struct WebSocketConfig {
 
 impl Default for WebSocketConfig {
     fn default() -> Self {
-        // Load environment variables from .env file if it exists
-        {
-            if dotenv::dotenv().is_err() {
-                // .env file not found or error loading, continue with system env vars
-            }
-        }
+        Self::try_new().unwrap_or_else(|_| {
+            // Reached only when a user-supplied `DERIBIT_WS_URL` is invalid.
+            // Fall back to the compile-time constant
+            // [`constants::PRODUCTION_WS_URL`], whose parse-ability is locked
+            // by the `test_production_ws_url_parses` unit test — making this
+            // branch unreachable in practice.
+            #[allow(
+                clippy::expect_used,
+                reason = "PRODUCTION_WS_URL is a compile-time constant validated by test_production_ws_url_parses"
+            )]
+            let ws_url = Url::parse(constants::PRODUCTION_WS_URL)
+                .expect("PRODUCTION_WS_URL is a compile-time constant validated by tests");
+            Self::from_parts(ws_url)
+        })
+    }
+}
 
-        let ws_url = env::var("DERIBIT_WS_URL")
-            .unwrap_or_else(|_| "wss://www.deribit.com/ws/api/v2".to_string());
+impl WebSocketConfig {
+    /// Construct a configuration from environment variables, propagating
+    /// parse errors for any user-supplied URL.
+    ///
+    /// Loads `.env` if present, reads `DERIBIT_WS_URL` (falling back to
+    /// [`constants::PRODUCTION_WS_URL`] when unset), and parses it. All other
+    /// fields follow the same env-or-default strategy as [`Default`] but
+    /// never fail.
+    ///
+    /// Prefer this over [`Default::default`] when the caller needs to surface
+    /// an invalid `DERIBIT_WS_URL` as an error instead of silently falling
+    /// back to the production URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`url::ParseError`] when `DERIBIT_WS_URL` is set to a value
+    /// that cannot be parsed as a URL.
+    pub fn try_new() -> Result<Self, url::ParseError> {
+        // Load .env if present; ignore missing-file errors.
+        let _ = dotenv::dotenv();
+
+        let ws_url_str =
+            env::var("DERIBIT_WS_URL").unwrap_or_else(|_| constants::PRODUCTION_WS_URL.to_string());
+        let ws_url = Url::parse(&ws_url_str)?;
+        Ok(Self::from_parts(ws_url))
+    }
+
+    /// Create a new configuration with a custom URL.
+    ///
+    /// Non-URL fields are populated from environment variables using the
+    /// same rules as [`Default`]; only the URL is overridden.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`url::ParseError`] when `url` cannot be parsed.
+    pub fn with_url(url: &str) -> Result<Self, url::ParseError> {
+        let ws_url = Url::parse(url)?;
+        // `from_parts` loads `.env` and reads every non-URL env var.
+        Ok(Self::from_parts(ws_url))
+    }
+
+    /// Private helper: populate every field except `ws_url` from environment
+    /// variables (with sensible defaults) and combine them with the given URL.
+    ///
+    /// `.env` loading is attempted here so every public constructor picks up
+    /// local overrides without having to duplicate the call.
+    fn from_parts(ws_url: Url) -> Self {
+        // Load environment variables from .env file if it exists. Idempotent
+        // and harmless when called more than once per process.
+        let _ = dotenv::dotenv();
 
         let heartbeat_interval = env::var("DERIBIT_HEARTBEAT_INTERVAL")
             .ok()
@@ -115,11 +175,7 @@ impl Default for WebSocketConfig {
             .unwrap_or(64);
 
         Self {
-            // TODO(#48): Replace Default with a fallible constructor so this
-            // hard-coded fallback URL does not rely on an `.unwrap()`.
-            #[allow(clippy::unwrap_used)]
-            ws_url: Url::parse(&ws_url)
-                .unwrap_or_else(|_| Url::parse("wss://www.deribit.com/ws/api/v2").unwrap()),
+            ws_url,
             heartbeat_interval,
             max_reconnect_attempts,
             reconnect_delay,
@@ -133,16 +189,6 @@ impl Default for WebSocketConfig {
             notification_channel_capacity,
             dispatcher_command_capacity,
         }
-    }
-}
-
-impl WebSocketConfig {
-    /// Create a new configuration with custom URL
-    pub fn with_url(url: &str) -> Result<Self, url::ParseError> {
-        Ok(Self {
-            ws_url: Url::parse(url)?,
-            ..Default::default()
-        })
     }
 
     /// Set heartbeat interval

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,10 +73,10 @@ impl WebSocketConfig {
     /// Construct a configuration from environment variables, propagating
     /// parse errors for any user-supplied URL.
     ///
-    /// Loads `.env` if present, reads `DERIBIT_WS_URL` (falling back to
-    /// [`constants::PRODUCTION_WS_URL`] when unset), and parses it. All other
-    /// fields follow the same env-or-default strategy as [`Default`] but
-    /// never fail.
+    /// Loads `.env` once via [`Self::load_env`], reads `DERIBIT_WS_URL`
+    /// (falling back to [`constants::PRODUCTION_WS_URL`] when unset), and
+    /// parses it. All other fields follow the same env-or-default strategy as
+    /// [`Default`] but never fail.
     ///
     /// Prefer this over [`Default::default`] when the caller needs to surface
     /// an invalid `DERIBIT_WS_URL` as an error instead of silently falling
@@ -87,9 +87,7 @@ impl WebSocketConfig {
     /// Returns [`url::ParseError`] when `DERIBIT_WS_URL` is set to a value
     /// that cannot be parsed as a URL.
     pub fn try_new() -> Result<Self, url::ParseError> {
-        // Load .env if present; ignore missing-file errors.
-        let _ = dotenv::dotenv();
-
+        Self::load_env();
         let ws_url_str =
             env::var("DERIBIT_WS_URL").unwrap_or_else(|_| constants::PRODUCTION_WS_URL.to_string());
         let ws_url = Url::parse(&ws_url_str)?;
@@ -99,27 +97,36 @@ impl WebSocketConfig {
     /// Create a new configuration with a custom URL.
     ///
     /// Non-URL fields are populated from environment variables using the
-    /// same rules as [`Default`]; only the URL is overridden.
+    /// same rules as [`Default`]; only the URL is overridden. `.env` is
+    /// loaded once via [`Self::load_env`] before any env var is read.
     ///
     /// # Errors
     ///
     /// Returns [`url::ParseError`] when `url` cannot be parsed.
     pub fn with_url(url: &str) -> Result<Self, url::ParseError> {
+        Self::load_env();
         let ws_url = Url::parse(url)?;
-        // `from_parts` loads `.env` and reads every non-URL env var.
         Ok(Self::from_parts(ws_url))
+    }
+
+    /// Centralised `.env` loader for every public constructor.
+    ///
+    /// Idempotent and harmless when called multiple times per process. Every
+    /// public entry point ([`Self::try_new`], [`Self::with_url`], and
+    /// [`Default::default`] via `try_new`) calls this exactly once before
+    /// reading any env var, so [`Self::from_parts`] can assume the environment
+    /// is already loaded.
+    fn load_env() {
+        let _ = dotenv::dotenv();
     }
 
     /// Private helper: populate every field except `ws_url` from environment
     /// variables (with sensible defaults) and combine them with the given URL.
     ///
-    /// `.env` loading is attempted here so every public constructor picks up
-    /// local overrides without having to duplicate the call.
+    /// The caller is responsible for calling [`Self::load_env`] beforehand so
+    /// that `.env` overrides are visible to `std::env::var`. Every public
+    /// constructor satisfies this invariant.
     fn from_parts(ws_url: Url) -> Self {
-        // Load environment variables from .env file if it exists. Idempotent
-        // and harmless when called more than once per process.
-        let _ = dotenv::dotenv();
-
         let heartbeat_interval = env::var("DERIBIT_HEARTBEAT_INTERVAL")
             .ok()
             .and_then(|s| s.parse().ok())

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -147,3 +147,29 @@ pub mod channels {
     /// User lock channel
     pub const USER_LOCK: &str = "user.lock";
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    /// Locks the invariant that [`WebSocketConfig::default`] relies on in
+    /// `config.rs`: parsing [`PRODUCTION_WS_URL`] must succeed. If this test
+    /// ever fails, the `.expect` in `Default::default` becomes a panic.
+    #[test]
+    fn test_production_ws_url_parses() {
+        let url = Url::parse(PRODUCTION_WS_URL).expect("PRODUCTION_WS_URL must parse");
+        assert_eq!(url.scheme(), "wss");
+        assert_eq!(url.host_str(), Some("www.deribit.com"));
+        assert_eq!(url.path(), "/ws/api/v2");
+    }
+
+    #[test]
+    fn test_testnet_ws_url_parses() {
+        let url = Url::parse(TESTNET_WS_URL).expect("TESTNET_WS_URL must parse");
+        assert_eq!(url.scheme(), "wss");
+        assert_eq!(url.host_str(), Some("test.deribit.com"));
+        assert_eq!(url.path(), "/ws/api/v2");
+    }
+}

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -1,6 +1,7 @@
 //! Unit tests for config module
 
 use deribit_websocket::config::WebSocketConfig;
+use deribit_websocket::constants;
 use std::time::Duration;
 
 #[test]
@@ -166,4 +167,114 @@ fn test_config_get_credentials_some() {
     let (id, secret) = creds.unwrap();
     assert_eq!(id, "client_id");
     assert_eq!(secret, "client_secret");
+}
+
+// =============================================================================
+// Fallible constructor + Default fallback tests (Issue #48)
+//
+// These tests mutate the `DERIBIT_WS_URL` environment variable, so they are
+// serialised to prevent cross-test races. The process-global env is restored
+// to its original state at the end of each test via a guard.
+// =============================================================================
+
+/// RAII guard that restores the previous value of `DERIBIT_WS_URL` on drop
+/// so one test's env mutation does not leak into the next one.
+struct WsUrlEnvGuard {
+    previous: Option<String>,
+}
+
+impl WsUrlEnvGuard {
+    fn capture() -> Self {
+        Self {
+            previous: std::env::var("DERIBIT_WS_URL").ok(),
+        }
+    }
+
+    fn set(value: &str) {
+        // SAFETY: tests carrying this guard are `#[serial_test::serial]`, so no
+        // other thread in this process mutates the env concurrently.
+        unsafe {
+            std::env::set_var("DERIBIT_WS_URL", value);
+        }
+    }
+}
+
+impl Drop for WsUrlEnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => {
+                // SAFETY: see `WsUrlEnvGuard::set`.
+                unsafe {
+                    std::env::set_var("DERIBIT_WS_URL", value);
+                }
+            }
+            None => {
+                // SAFETY: see `WsUrlEnvGuard::set`.
+                unsafe {
+                    std::env::remove_var("DERIBIT_WS_URL");
+                }
+            }
+        }
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_try_new_returns_ok_with_valid_env_url() {
+    let _guard = WsUrlEnvGuard::capture();
+    WsUrlEnvGuard::set("wss://custom.example.com/ws");
+
+    let result = WebSocketConfig::try_new();
+    assert!(
+        result.is_ok(),
+        "try_new should succeed with a valid user URL"
+    );
+    assert_eq!(
+        result.unwrap().ws_url.as_str(),
+        "wss://custom.example.com/ws"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn test_try_new_returns_err_on_invalid_env_url() {
+    let _guard = WsUrlEnvGuard::capture();
+    WsUrlEnvGuard::set("not-a-valid-url");
+
+    let result = WebSocketConfig::try_new();
+    assert!(
+        result.is_err(),
+        "try_new must propagate url::ParseError for invalid env URL, got {result:?}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn test_default_falls_back_on_invalid_env_url() {
+    let _guard = WsUrlEnvGuard::capture();
+    WsUrlEnvGuard::set("not-a-valid-url");
+
+    // Default must NEVER panic; it silently falls back to PRODUCTION_WS_URL.
+    let config = WebSocketConfig::default();
+    assert_eq!(config.ws_url.as_str(), constants::PRODUCTION_WS_URL);
+}
+
+#[test]
+#[serial_test::serial]
+fn test_with_url_accepts_valid_url() {
+    // Regression guard for the `with_url` refactor (issue #48).
+    let custom = "wss://custom.example.com/ws";
+    let config = WebSocketConfig::with_url(custom).expect("valid URL must parse in with_url");
+    assert_eq!(config.ws_url.as_str(), custom);
+}
+
+#[test]
+#[serial_test::serial]
+fn test_with_url_returns_err_on_invalid_url() {
+    // Regression guard for the `with_url` refactor (issue #48).
+    let result = WebSocketConfig::with_url("not-a-valid-url");
+    assert!(
+        result.is_err(),
+        "with_url must propagate url::ParseError for invalid URL, got {result:?}"
+    );
 }

--- a/tests/unit/config.rs
+++ b/tests/unit/config.rs
@@ -5,13 +5,18 @@ use deribit_websocket::constants;
 use std::time::Duration;
 
 #[test]
+#[serial_test::serial]
 fn test_default_config() {
-    let config = unsafe {
-        std::env::set_var("DERIBIT_WS_URL", "wss://www.deribit.com/ws/api/v2");
-        std::env::remove_var("DERIBIT_TEST_MODE");
-        std::env::remove_var("DERIBIT_RECONNECT_DELAY");
-        WebSocketConfig::default()
-    };
+    let _guard = DeribitEnvGuard::capture(&[
+        "DERIBIT_WS_URL",
+        "DERIBIT_TEST_MODE",
+        "DERIBIT_RECONNECT_DELAY",
+    ]);
+    DeribitEnvGuard::set("DERIBIT_WS_URL", "wss://www.deribit.com/ws/api/v2");
+    DeribitEnvGuard::remove("DERIBIT_TEST_MODE");
+    DeribitEnvGuard::remove("DERIBIT_RECONNECT_DELAY");
+
+    let config = WebSocketConfig::default();
 
     assert_eq!(config.ws_url.as_str(), "wss://www.deribit.com/ws/api/v2");
     assert_eq!(config.heartbeat_interval, Duration::from_secs(30));
@@ -48,16 +53,21 @@ fn test_config_builder_pattern() {
 }
 
 #[test]
+#[serial_test::serial]
 fn test_config_chaining() {
-    let config = unsafe {
-        std::env::set_var("DERIBIT_WS_URL", "wss://www.deribit.com/ws/api/v2");
-        std::env::remove_var("DERIBIT_TEST_MODE");
-        std::env::remove_var("DERIBIT_RECONNECT_DELAY");
-        WebSocketConfig::default()
-    }
-    .with_heartbeat_interval(Duration::from_secs(45))
-    .with_max_reconnect_attempts(3)
-    .with_reconnect_delay(Duration::from_millis(500));
+    let _guard = DeribitEnvGuard::capture(&[
+        "DERIBIT_WS_URL",
+        "DERIBIT_TEST_MODE",
+        "DERIBIT_RECONNECT_DELAY",
+    ]);
+    DeribitEnvGuard::set("DERIBIT_WS_URL", "wss://www.deribit.com/ws/api/v2");
+    DeribitEnvGuard::remove("DERIBIT_TEST_MODE");
+    DeribitEnvGuard::remove("DERIBIT_RECONNECT_DELAY");
+
+    let config = WebSocketConfig::default()
+        .with_heartbeat_interval(Duration::from_secs(45))
+        .with_max_reconnect_attempts(3)
+        .with_reconnect_delay(Duration::from_millis(500));
 
     assert_eq!(config.ws_url.as_str(), "wss://www.deribit.com/ws/api/v2");
     assert_eq!(config.heartbeat_interval, Duration::from_secs(45));
@@ -170,48 +180,67 @@ fn test_config_get_credentials_some() {
 }
 
 // =============================================================================
-// Fallible constructor + Default fallback tests (Issue #48)
+// Env-mutation guard + fallible constructor tests (Issue #48)
 //
-// These tests mutate the `DERIBIT_WS_URL` environment variable, so they are
-// serialised to prevent cross-test races. The process-global env is restored
-// to its original state at the end of each test via a guard.
+// Every test in this module that touches `DERIBIT_*` env vars is marked
+// `#[serial_test::serial]` under the same (default) key, so that the safety
+// precondition of `std::env::set_var`/`remove_var` — no concurrent env
+// mutation in this process — actually holds. `DeribitEnvGuard` captures the
+// previous value of each named var and restores it on drop, so mutations do
+// not leak between tests.
 // =============================================================================
 
-/// RAII guard that restores the previous value of `DERIBIT_WS_URL` on drop
-/// so one test's env mutation does not leak into the next one.
-struct WsUrlEnvGuard {
-    previous: Option<String>,
+/// RAII guard that captures the previous values of the supplied env vars and
+/// restores them on drop. Call `set`/`remove` to mutate tracked vars inside
+/// the guarded scope.
+///
+/// Every caller must be `#[serial_test::serial]`; that is the sole basis for
+/// the `unsafe` blocks below being sound.
+struct DeribitEnvGuard {
+    previous: Vec<(&'static str, Option<String>)>,
 }
 
-impl WsUrlEnvGuard {
-    fn capture() -> Self {
+impl DeribitEnvGuard {
+    fn capture(vars: &[&'static str]) -> Self {
         Self {
-            previous: std::env::var("DERIBIT_WS_URL").ok(),
+            previous: vars
+                .iter()
+                .map(|name| (*name, std::env::var(name).ok()))
+                .collect(),
         }
     }
 
-    fn set(value: &str) {
-        // SAFETY: tests carrying this guard are `#[serial_test::serial]`, so no
-        // other thread in this process mutates the env concurrently.
+    fn set(name: &str, value: &str) {
+        // SAFETY: every test using this guard is `#[serial_test::serial]`,
+        // so no other thread in this process mutates the env concurrently.
         unsafe {
-            std::env::set_var("DERIBIT_WS_URL", value);
+            std::env::set_var(name, value);
+        }
+    }
+
+    fn remove(name: &str) {
+        // SAFETY: see `DeribitEnvGuard::set`.
+        unsafe {
+            std::env::remove_var(name);
         }
     }
 }
 
-impl Drop for WsUrlEnvGuard {
+impl Drop for DeribitEnvGuard {
     fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => {
-                // SAFETY: see `WsUrlEnvGuard::set`.
-                unsafe {
-                    std::env::set_var("DERIBIT_WS_URL", value);
+        for (name, previous) in &self.previous {
+            match previous {
+                Some(value) => {
+                    // SAFETY: see `DeribitEnvGuard::set`.
+                    unsafe {
+                        std::env::set_var(name, value);
+                    }
                 }
-            }
-            None => {
-                // SAFETY: see `WsUrlEnvGuard::set`.
-                unsafe {
-                    std::env::remove_var("DERIBIT_WS_URL");
+                None => {
+                    // SAFETY: see `DeribitEnvGuard::set`.
+                    unsafe {
+                        std::env::remove_var(name);
+                    }
                 }
             }
         }
@@ -221,8 +250,8 @@ impl Drop for WsUrlEnvGuard {
 #[test]
 #[serial_test::serial]
 fn test_try_new_returns_ok_with_valid_env_url() {
-    let _guard = WsUrlEnvGuard::capture();
-    WsUrlEnvGuard::set("wss://custom.example.com/ws");
+    let _guard = DeribitEnvGuard::capture(&["DERIBIT_WS_URL"]);
+    DeribitEnvGuard::set("DERIBIT_WS_URL", "wss://custom.example.com/ws");
 
     let result = WebSocketConfig::try_new();
     assert!(
@@ -238,8 +267,8 @@ fn test_try_new_returns_ok_with_valid_env_url() {
 #[test]
 #[serial_test::serial]
 fn test_try_new_returns_err_on_invalid_env_url() {
-    let _guard = WsUrlEnvGuard::capture();
-    WsUrlEnvGuard::set("not-a-valid-url");
+    let _guard = DeribitEnvGuard::capture(&["DERIBIT_WS_URL"]);
+    DeribitEnvGuard::set("DERIBIT_WS_URL", "not-a-valid-url");
 
     let result = WebSocketConfig::try_new();
     assert!(
@@ -251,8 +280,8 @@ fn test_try_new_returns_err_on_invalid_env_url() {
 #[test]
 #[serial_test::serial]
 fn test_default_falls_back_on_invalid_env_url() {
-    let _guard = WsUrlEnvGuard::capture();
-    WsUrlEnvGuard::set("not-a-valid-url");
+    let _guard = DeribitEnvGuard::capture(&["DERIBIT_WS_URL"]);
+    DeribitEnvGuard::set("DERIBIT_WS_URL", "not-a-valid-url");
 
     // Default must NEVER panic; it silently falls back to PRODUCTION_WS_URL.
     let config = WebSocketConfig::default();


### PR DESCRIPTION
## Summary

Closes the last `.unwrap()` left in `src/config.rs` — the one on the hardcoded fallback URL inside `WebSocketConfig::Default`. Replaces the ad-hoc pattern with a proper fallible constructor (`try_new`) plus a single narrowly-allowed `.expect()` backed by a unit test that locks the underlying constant's parseability.

## Changes

- **New API**: `WebSocketConfig::try_new() -> Result<Self, url::ParseError>` — purely additive. Reads `DERIBIT_WS_URL` (falling back to `constants::PRODUCTION_WS_URL`) and propagates parse errors for invalid user input.
- **Private helper**: `WebSocketConfig::from_parts(ws_url: Url) -> Self` — single source of truth for the env-reading boilerplate. `Default`, `try_new`, and `with_url` all delegate to it.
- **`Default`** is rewritten to call `try_new` and fall back to `PRODUCTION_WS_URL` on parse failure. The single remaining `.expect()` carries a narrow `#[allow(clippy::expect_used, reason = "...")]` pointing at the unit test that guarantees the constant parses.
- **`with_url`** no longer parses a URL via `Default::default` and immediately throws it away; it builds via `from_parts` directly.
- Both hardcoded `"wss://www.deribit.com/ws/api/v2"` strings in `config.rs` are replaced with `constants::PRODUCTION_WS_URL`.

## Tests

- `src/constants.rs` gains an in-file test module with `test_production_ws_url_parses` and `test_testnet_ws_url_parses`. The first is the invariant backing the lone `.expect()` in `Default`.
- `tests/unit/config.rs` gains 5 tests:
  - `test_try_new_returns_ok_with_valid_env_url`
  - `test_try_new_returns_err_on_invalid_env_url`
  - `test_default_falls_back_on_invalid_env_url`
  - `test_with_url_accepts_valid_url`
  - `test_with_url_returns_err_on_invalid_url`

  Each new test is `#[serial_test::serial]` with an RAII guard that captures and restores `DERIBIT_WS_URL` on drop so nothing leaks between tests.

## Design Decisions

- **Reuse `PRODUCTION_WS_URL`** instead of adding a new `DEFAULT_WS_URL` alias — it already existed with the same value and pairs cleanly with `TESTNET_WS_URL`.
- **Keep `Default` lenient**. Invalid env URL still silently falls back to the production URL, preserving backward compatibility. Callers who want the strict behaviour switch to `try_new`.
- **One `.expect` allowed**, not zero. The narrow `#[allow(clippy::expect_used, reason = "...")]` is explicit about why: the constant is unit-tested. No `.unwrap()` and no `#[allow(clippy::unwrap_used)]` remain in `config.rs`.

## Acceptance Criteria (from the issue)

- [x] No trailing `.unwrap()` in `src/config.rs` — `rg '\.unwrap\(\)' src/config.rs` returns zero hits.
- [x] Unit test asserts the default URL parses — `test_production_ws_url_parses` in `src/constants.rs`.
- [x] Default URL constant lives in `src/constants.rs` — reused the existing `PRODUCTION_WS_URL`.

## Verification

All `make check` stages pass locally:

- `cargo test --all-features` — 432 tests pass (7 new).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo clippy --lib --tests --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` — clean.
- `cargo fmt --check` — clean.

Closes #48
