### PR TITLE
#62: Reconcile subscribe/unsubscribe local state with server response

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -173,59 +173,68 @@ impl DeribitWebSocketClient {
         }
     }
 
-    /// Subscribe to channels
+    /// Subscribe to channels.
     ///
-    /// Local subscription state is updated only after the server confirms
-    /// the subscribe with a `JsonRpcResult::Success`. Transport failures
-    /// and API errors leave the local view untouched. Server-side partial
-    /// success (the response `result` array may be shorter than the
-    /// requested channel list) is not yet reconciled — see follow-up
-    /// issue.
+    /// Local subscription state is reconciled against the server-confirmed
+    /// channel list carried by `response.result`, which may be a strict
+    /// subset of the requested channels when the server rejects individual
+    /// entries (unknown channel, permission denied, rate limit). Only the
+    /// channels the server actually acknowledged are added to the local
+    /// [`SubscriptionManager`]. Transport failures and API-error responses
+    /// leave the local view untouched so the caller can retry without
+    /// inconsistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::InvalidMessage`] if a `Success` response
+    /// carries a `result` that is not a JSON array of channel strings.
     pub async fn subscribe(
         &self,
         channels: Vec<String>,
     ) -> Result<JsonRpcResponse, WebSocketError> {
         let request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_subscribe_request(channels.clone())
+            builder.build_subscribe_request(channels)
         };
 
         let response = self.send_request(request).await?;
 
-        if matches!(response.result, JsonRpcResult::Success { .. }) {
+        {
             let mut sub_manager = self.subscription_manager.lock().await;
-            for channel in channels {
-                let channel_type = self.parse_channel_type(&channel);
-                let instrument = self.extract_instrument(&channel);
-                sub_manager.add_subscription(channel, channel_type, instrument);
-            }
+            apply_subscribe_confirmation(&mut sub_manager, &response)?;
         }
 
         Ok(response)
     }
 
-    /// Unsubscribe from channels
+    /// Unsubscribe from channels.
     ///
-    /// Local subscription state is updated only after the server confirms
-    /// the unsubscribe with a `JsonRpcResult::Success`. Transport failures
-    /// and API errors leave the local view untouched so the caller can
-    /// retry without inconsistency.
+    /// Local subscription state is reconciled against the server-confirmed
+    /// channel list carried by `response.result`, which may be a strict
+    /// subset of the requested channels. Only the channels the server
+    /// actually acknowledged are removed from the local
+    /// [`SubscriptionManager`]. Transport failures and API-error responses
+    /// leave the local view untouched so the caller can retry without
+    /// inconsistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::InvalidMessage`] if a `Success` response
+    /// carries a `result` that is not a JSON array of channel strings.
     pub async fn unsubscribe(
         &self,
         channels: Vec<String>,
     ) -> Result<JsonRpcResponse, WebSocketError> {
         let request = {
             let mut builder = self.request_builder.lock().await;
-            builder.build_unsubscribe_request(channels.clone())
+            builder.build_unsubscribe_request(channels)
         };
 
         let response = self.send_request(request).await?;
 
-        if matches!(response.result, JsonRpcResult::Success { .. }) {
+        {
             let mut sub_manager = self.subscription_manager.lock().await;
-            for channel in channels {
-                sub_manager.remove_subscription(&channel);
-            }
+            apply_unsubscribe_confirmation(&mut sub_manager, &response)?;
         }
 
         Ok(response)
@@ -1308,46 +1317,6 @@ impl DeribitWebSocketClient {
 
         Ok(())
     }
-
-    // Helper methods
-
-    /// Parse a channel string into a `SubscriptionChannel` variant
-    ///
-    /// Uses `SubscriptionChannel::from_string()` to properly detect all channel types.
-    /// Unknown channels are returned as `SubscriptionChannel::Unknown(String)`.
-    fn parse_channel_type(&self, channel: &str) -> SubscriptionChannel {
-        SubscriptionChannel::from_string(channel)
-    }
-
-    fn extract_instrument(&self, channel: &str) -> Option<String> {
-        let parts: Vec<&str> = channel.split('.').collect();
-        match parts.as_slice() {
-            ["ticker", instrument] | ["ticker", instrument, _] => Some(instrument.to_string()),
-            ["book", instrument, ..] => Some(instrument.to_string()),
-            ["trades", instrument, ..] => Some(instrument.to_string()),
-            ["chart", "trades", instrument, _] => Some(instrument.to_string()),
-            ["user", "changes", instrument, _] => Some(instrument.to_string()),
-            ["estimated_expiration_price", instrument] => Some(instrument.to_string()),
-            ["markprice", "options", instrument] => Some(instrument.to_string()),
-            ["perpetual", instrument, _] => Some(instrument.to_string()),
-            ["quote", instrument] => Some(instrument.to_string()),
-            ["incremental_ticker", instrument] => Some(instrument.to_string()),
-            ["deribit_price_index", index_name]
-            | ["deribit_price_ranking", index_name]
-            | ["deribit_price_statistics", index_name]
-            | ["deribit_volatility_index", index_name] => Some(index_name.to_string()),
-            ["instrument", "state", _kind, currency] => Some(currency.to_string()),
-            ["block_rfq", "trades", currency] => Some(currency.to_string()),
-            ["block_trade_confirmations", currency] => Some(currency.to_string()),
-            ["user", "mmp_trigger", index_name] => Some(index_name.to_string()),
-            ["platform_state"]
-            | ["platform_state", "public_methods_state"]
-            | ["block_trade_confirmations"]
-            | ["user", "access_log"]
-            | ["user", "lock"] => None,
-            _ => None,
-        }
-    }
 }
 
 impl Default for DeribitWebSocketClient {
@@ -1358,5 +1327,464 @@ impl Default for DeribitWebSocketClient {
         // Tracked separately for a fallible-only constructor redesign.
         #[allow(clippy::unwrap_used)]
         Self::new(&config).unwrap()
+    }
+}
+
+/// Apply a server-confirmed `public/subscribe` response to `manager`.
+///
+/// Parses the JSON array carried by `response.result` as a list of channel
+/// names and adds each to the manager. Deribit's response is the set of
+/// channels actually accepted by the server — a possible strict subset of
+/// the requested list when individual channels are rejected (unknown
+/// channel, permission denied, rate limit). Only this reconciled set
+/// appears in the local view; the caller's input list is never consulted.
+///
+/// API-error responses ([`JsonRpcResult::Error`]) are a no-op: the caller
+/// returns them verbatim so the error surface is visible to the caller.
+///
+/// # Errors
+///
+/// Returns [`WebSocketError::InvalidMessage`] when a `Success` response
+/// carries a `result` value that cannot be parsed as `Vec<String>`.
+fn apply_subscribe_confirmation(
+    manager: &mut SubscriptionManager,
+    response: &JsonRpcResponse,
+) -> Result<(), WebSocketError> {
+    let confirmed = match confirmed_channels(response, "public/subscribe")? {
+        Some(list) => list,
+        None => return Ok(()),
+    };
+    for channel in confirmed {
+        let channel_type = SubscriptionChannel::from_string(&channel);
+        let instrument = instrument_from_channel(&channel);
+        manager.add_subscription(channel, channel_type, instrument);
+    }
+    Ok(())
+}
+
+/// Apply a server-confirmed `public/unsubscribe` response to `manager`.
+///
+/// Mirror of [`apply_subscribe_confirmation`] for the unsubscribe path:
+/// only the channels the server actually unsubscribed are removed from the
+/// local view. API-error responses are a no-op.
+///
+/// # Errors
+///
+/// Returns [`WebSocketError::InvalidMessage`] when a `Success` response
+/// carries a `result` value that cannot be parsed as `Vec<String>`.
+fn apply_unsubscribe_confirmation(
+    manager: &mut SubscriptionManager,
+    response: &JsonRpcResponse,
+) -> Result<(), WebSocketError> {
+    let confirmed = match confirmed_channels(response, "public/unsubscribe")? {
+        Some(list) => list,
+        None => return Ok(()),
+    };
+    for channel in confirmed {
+        manager.remove_subscription(&channel);
+    }
+    Ok(())
+}
+
+/// Extract the confirmed channel list from a subscribe/unsubscribe response.
+///
+/// - `Success` with a JSON array of strings → `Ok(Some(list))`.
+/// - `Success` with any other shape → `Err(InvalidMessage)`.
+/// - `Error` → `Ok(None)`, signalling the caller to leave local state
+///   untouched. The caller is expected to return the [`JsonRpcResponse`]
+///   to its own caller so the API error surfaces.
+fn confirmed_channels(
+    response: &JsonRpcResponse,
+    method: &'static str,
+) -> Result<Option<Vec<String>>, WebSocketError> {
+    match &response.result {
+        JsonRpcResult::Success { result } => serde_json::from_value::<Vec<String>>(result.clone())
+            .map(Some)
+            .map_err(|e| {
+                WebSocketError::InvalidMessage(format!(
+                    "expected array of confirmed channel strings in {} response: {}",
+                    method, e
+                ))
+            }),
+        JsonRpcResult::Error { .. } => Ok(None),
+    }
+}
+
+/// Extract the instrument/currency/index token carried by a channel name.
+///
+/// Plain-function counterpart of `DeribitWebSocketClient::extract_instrument`
+/// so the reconciliation helpers can run without a client instance (and
+/// therefore be unit-tested in isolation). Keeps the same pattern-match
+/// shape as the method to avoid drift.
+fn instrument_from_channel(channel: &str) -> Option<String> {
+    let parts: Vec<&str> = channel.split('.').collect();
+    match parts.as_slice() {
+        ["ticker", instrument] | ["ticker", instrument, _] => Some((*instrument).to_string()),
+        ["book", instrument, ..] => Some((*instrument).to_string()),
+        ["trades", instrument, ..] => Some((*instrument).to_string()),
+        ["chart", "trades", instrument, _] => Some((*instrument).to_string()),
+        ["user", "changes", instrument, _] => Some((*instrument).to_string()),
+        ["estimated_expiration_price", instrument] => Some((*instrument).to_string()),
+        ["markprice", "options", instrument] => Some((*instrument).to_string()),
+        ["perpetual", instrument, _] => Some((*instrument).to_string()),
+        ["quote", instrument] => Some((*instrument).to_string()),
+        ["incremental_ticker", instrument] => Some((*instrument).to_string()),
+        ["deribit_price_index", index_name]
+        | ["deribit_price_ranking", index_name]
+        | ["deribit_price_statistics", index_name]
+        | ["deribit_volatility_index", index_name] => Some((*index_name).to_string()),
+        ["instrument", "state", _kind, currency] => Some((*currency).to_string()),
+        ["block_rfq", "trades", currency] => Some((*currency).to_string()),
+        ["block_trade_confirmations", currency] => Some((*currency).to_string()),
+        ["user", "mmp_trigger", index_name] => Some((*index_name).to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Reconciliation tests for `subscribe` / `unsubscribe` (issue #62).
+    //!
+    //! The bulk are stubbed-response tests that drive the pure sync
+    //! helpers ([`apply_subscribe_confirmation`] /
+    //! [`apply_unsubscribe_confirmation`]) directly with hand-crafted
+    //! [`JsonRpcResponse`] values and a bare [`SubscriptionManager`]. One
+    //! end-to-end test stands up a mock WebSocket server and exercises
+    //! the full [`DeribitWebSocketClient::subscribe`] path to prove the
+    //! acceptance criterion from the issue.
+    use super::*;
+    use crate::model::ws_types::JsonRpcError;
+    use serde_json::json;
+
+    /// Build a `Success` response carrying `result`.
+    fn success(result: serde_json::Value) -> JsonRpcResponse {
+        JsonRpcResponse::success(json!(1), result)
+    }
+
+    /// Build an `Error` response with a realistic Deribit-style shape.
+    fn api_error(code: i32, message: &str) -> JsonRpcResponse {
+        JsonRpcResponse::error(
+            json!(1),
+            JsonRpcError {
+                code,
+                message: message.to_string(),
+                data: None,
+            },
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // Stubbed-response unit tests: apply_subscribe_confirmation
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_apply_subscribe_confirmation_adds_only_server_confirmed_channels() {
+        // Core acceptance criterion for issue #62: caller requested two
+        // channels, server accepted only one. Local view must reflect
+        // the server-confirmed subset — never the input.
+        let mut manager = SubscriptionManager::new();
+        let response = success(json!(["ticker.BTC-PERPETUAL"]));
+
+        apply_subscribe_confirmation(&mut manager, &response)
+            .expect("well-formed success response reconciles");
+
+        let channels = manager.get_all_channels();
+        assert_eq!(channels, vec!["ticker.BTC-PERPETUAL".to_string()]);
+        assert!(
+            manager.get_subscription("ticker.INVALID").is_none(),
+            "rejected input channel must not leak into local state"
+        );
+    }
+
+    #[test]
+    fn test_apply_subscribe_confirmation_happy_path_input_equals_response() {
+        // Regression guard: when the server confirms everything the
+        // caller asked for, every requested channel lands in the manager.
+        let mut manager = SubscriptionManager::new();
+        let response = success(json!(["ticker.BTC-PERPETUAL", "book.ETH-PERPETUAL.raw"]));
+
+        apply_subscribe_confirmation(&mut manager, &response)
+            .expect("happy-path response reconciles");
+
+        let mut channels = manager.get_all_channels();
+        channels.sort();
+        assert_eq!(
+            channels,
+            vec![
+                "book.ETH-PERPETUAL.raw".to_string(),
+                "ticker.BTC-PERPETUAL".to_string(),
+            ]
+        );
+        // Instrument extraction should populate the typed side too.
+        let ticker = manager
+            .get_subscription("ticker.BTC-PERPETUAL")
+            .expect("ticker subscription tracked");
+        assert_eq!(ticker.instrument.as_deref(), Some("BTC-PERPETUAL"));
+    }
+
+    #[test]
+    fn test_apply_subscribe_confirmation_empty_result_is_noop() {
+        // Server accepted zero of the requested channels. The function
+        // succeeds but makes no entries.
+        let mut manager = SubscriptionManager::new();
+        let response = success(json!([] as [&str; 0]));
+
+        apply_subscribe_confirmation(&mut manager, &response).expect("empty confirmation is valid");
+
+        assert!(manager.get_all_channels().is_empty());
+    }
+
+    #[test]
+    fn test_apply_subscribe_confirmation_api_error_is_noop() {
+        // API-error responses are surfaced to the caller verbatim and
+        // must leave the local view untouched so the caller can retry.
+        let mut manager = SubscriptionManager::new();
+        manager.add_subscription(
+            "ticker.BTC-PERPETUAL".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+        let before = manager.get_all_channels();
+        let response = api_error(-32000, "subscription rejected");
+
+        apply_subscribe_confirmation(&mut manager, &response)
+            .expect("api-error response must not return Err");
+
+        assert_eq!(
+            manager.get_all_channels(),
+            before,
+            "api-error response must not mutate the manager"
+        );
+    }
+
+    #[test]
+    fn test_apply_subscribe_confirmation_non_array_result_returns_invalid_message() {
+        // A `Success` whose `result` is not an array of strings is a
+        // protocol violation — we surface it as `InvalidMessage` rather
+        // than silently skipping reconciliation.
+        let mut manager = SubscriptionManager::new();
+        let response = success(json!({ "channels": ["ticker.BTC-PERPETUAL"] }));
+
+        let err = apply_subscribe_confirmation(&mut manager, &response)
+            .expect_err("object result must not parse as Vec<String>");
+        assert!(
+            matches!(err, WebSocketError::InvalidMessage(_)),
+            "expected InvalidMessage, got {:?}",
+            err
+        );
+        assert!(
+            manager.get_all_channels().is_empty(),
+            "failed reconciliation must not partially mutate the manager"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Stubbed-response unit tests: apply_unsubscribe_confirmation
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_apply_unsubscribe_confirmation_removes_only_server_confirmed_channels() {
+        // Mirror of the subscribe subset test: two channels live in the
+        // manager; the server confirms only one was unsubscribed. The
+        // other must stay.
+        let mut manager = SubscriptionManager::new();
+        manager.add_subscription(
+            "ticker.BTC-PERPETUAL".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+        manager.add_subscription(
+            "ticker.ETH-PERPETUAL".to_string(),
+            SubscriptionChannel::Ticker("ETH-PERPETUAL".to_string()),
+            Some("ETH-PERPETUAL".to_string()),
+        );
+        let response = success(json!(["ticker.BTC-PERPETUAL"]));
+
+        apply_unsubscribe_confirmation(&mut manager, &response)
+            .expect("well-formed unsubscribe response reconciles");
+
+        let channels = manager.get_all_channels();
+        assert_eq!(channels, vec!["ticker.ETH-PERPETUAL".to_string()]);
+    }
+
+    #[test]
+    fn test_apply_unsubscribe_confirmation_happy_path() {
+        // Regression guard: server confirms everything the caller asked
+        // to drop; the manager ends empty.
+        let mut manager = SubscriptionManager::new();
+        manager.add_subscription(
+            "ticker.BTC-PERPETUAL".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+        manager.add_subscription(
+            "book.ETH-PERPETUAL.raw".to_string(),
+            SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()),
+            Some("ETH-PERPETUAL".to_string()),
+        );
+        let response = success(json!(["ticker.BTC-PERPETUAL", "book.ETH-PERPETUAL.raw"]));
+
+        apply_unsubscribe_confirmation(&mut manager, &response)
+            .expect("happy-path unsubscribe reconciles");
+
+        assert!(manager.get_all_channels().is_empty());
+    }
+
+    #[test]
+    fn test_apply_unsubscribe_confirmation_api_error_is_noop() {
+        let mut manager = SubscriptionManager::new();
+        manager.add_subscription(
+            "ticker.BTC-PERPETUAL".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+        let before = manager.get_all_channels();
+        let response = api_error(-32000, "unsubscribe rejected");
+
+        apply_unsubscribe_confirmation(&mut manager, &response)
+            .expect("api-error response must not return Err");
+
+        assert_eq!(
+            manager.get_all_channels(),
+            before,
+            "api-error response must not mutate the manager"
+        );
+    }
+
+    #[test]
+    fn test_apply_unsubscribe_confirmation_non_array_result_returns_invalid_message() {
+        let mut manager = SubscriptionManager::new();
+        manager.add_subscription(
+            "ticker.BTC-PERPETUAL".to_string(),
+            SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+            Some("BTC-PERPETUAL".to_string()),
+        );
+        let response = success(json!("not an array"));
+
+        let err = apply_unsubscribe_confirmation(&mut manager, &response)
+            .expect_err("string result must not parse as Vec<String>");
+        assert!(
+            matches!(err, WebSocketError::InvalidMessage(_)),
+            "expected InvalidMessage, got {:?}",
+            err
+        );
+        assert_eq!(
+            manager.get_all_channels(),
+            vec!["ticker.BTC-PERPETUAL".to_string()],
+            "failed reconciliation must not partially mutate the manager"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // End-to-end mock WebSocket server test (acceptance criterion #1)
+    // ---------------------------------------------------------------
+
+    /// Spawn a single-shot mock WebSocket server on an ephemeral port.
+    ///
+    /// The `scenario` closure receives the split sink/stream for the one
+    /// accepted connection and drives the test-specific server-side
+    /// behaviour. Returns the bound address and a join handle the test
+    /// must await at the end to surface any panic from the task.
+    async fn spawn_mock_server<F, Fut>(
+        scenario: F,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>)
+    where
+        F: FnOnce(
+                futures_util::stream::SplitSink<
+                    tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+                    tokio_tungstenite::tungstenite::Message,
+                >,
+                futures_util::stream::SplitStream<
+                    tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+                >,
+            ) -> Fut
+            + Send
+            + 'static,
+        Fut: std::future::Future<Output = ()> + Send,
+    {
+        use futures_util::StreamExt;
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::accept_async;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind localhost ephemeral port");
+        let addr = listener
+            .local_addr()
+            .expect("read local addr of bound listener");
+        let handle = tokio::spawn(async move {
+            let (socket, _peer) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => return,
+            };
+            let ws = match accept_async(socket).await {
+                Ok(ws) => ws,
+                Err(_) => return,
+            };
+            let (sink, stream) = ws.split();
+            scenario(sink, stream).await;
+        });
+        (addr, handle)
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_reconciles_local_state_with_server_subset() {
+        // End-to-end proof of the issue #62 acceptance criterion:
+        //
+        //   client.subscribe(["ticker.INVALID", "ticker.BTC-PERPETUAL"])
+        //
+        // against a server that replies with `["ticker.BTC-PERPETUAL"]`
+        // leaves only BTC-PERPETUAL in the local manager.
+        use futures_util::{SinkExt, StreamExt};
+        use tokio_tungstenite::tungstenite::Message;
+
+        let (addr, server) = spawn_mock_server(|mut sink, mut stream| async move {
+            // Read the subscribe request, echo back only the BTC channel.
+            if let Some(Ok(Message::Text(t))) = stream.next().await {
+                let req: serde_json::Value =
+                    serde_json::from_str(&t).expect("server parses request");
+                let id = req.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": ["ticker.BTC-PERPETUAL"],
+                });
+                let _ = sink.send(Message::Text(resp.to_string().into())).await;
+            }
+            // Hold the socket open long enough for the client to read.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        })
+        .await;
+
+        let config = WebSocketConfig::with_url(&format!("ws://{}/", addr)).expect("valid ws url");
+        let client = DeribitWebSocketClient::new(&config).expect("client construction");
+        client.connect().await.expect("client connects to mock");
+
+        let response = client
+            .subscribe(vec![
+                "ticker.INVALID".to_string(),
+                "ticker.BTC-PERPETUAL".to_string(),
+            ])
+            .await
+            .expect("subscribe returns the server-confirmed response");
+
+        // Server-confirmed response is surfaced verbatim.
+        let JsonRpcResult::Success { result } = response.result else {
+            panic!("expected Success result, got {:?}", response.result);
+        };
+        assert_eq!(result, json!(["ticker.BTC-PERPETUAL"]));
+
+        // Local manager reflects the server-confirmed subset — only BTC,
+        // never the rejected INVALID channel.
+        let manager = client.subscription_manager();
+        let channels = manager.lock().await.get_all_channels();
+        assert_eq!(
+            channels,
+            vec!["ticker.BTC-PERPETUAL".to_string()],
+            "local manager must drop rejected channels from the input"
+        );
+
+        client.disconnect().await.expect("client disconnects");
+        server.await.expect("server task did not panic");
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1442,6 +1442,7 @@ fn instrument_from_channel(channel: &str) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     //! Reconciliation tests for `subscribe` / `unsubscribe` (issue #62).
     //!

--- a/src/client.rs
+++ b/src/client.rs
@@ -184,6 +184,12 @@ impl DeribitWebSocketClient {
     /// leave the local view untouched so the caller can retry without
     /// inconsistency.
     ///
+    /// The response is parsed and validated outside the
+    /// `subscription_manager` mutex so the lock is only held for the
+    /// `HashMap` mutations themselves, keeping the critical section
+    /// minimal under contention from `get_subscriptions`, concurrent
+    /// subscribes, or the notification consumer.
+    ///
     /// # Errors
     ///
     /// Returns [`WebSocketError::InvalidMessage`] if a `Success` response
@@ -199,9 +205,11 @@ impl DeribitWebSocketClient {
 
         let response = self.send_request(request).await?;
 
-        {
+        // Parse + validate the confirmed list outside the subscription
+        // mutex. Only acquire the lock once we have work to do.
+        if let Some(confirmed) = confirmed_channels(&response, "public/subscribe")? {
             let mut sub_manager = self.subscription_manager.lock().await;
-            apply_subscribe_confirmation(&mut sub_manager, &response)?;
+            add_confirmed_channels(&mut sub_manager, confirmed);
         }
 
         Ok(response)
@@ -216,6 +224,10 @@ impl DeribitWebSocketClient {
     /// [`SubscriptionManager`]. Transport failures and API-error responses
     /// leave the local view untouched so the caller can retry without
     /// inconsistency.
+    ///
+    /// The response is parsed and validated outside the
+    /// `subscription_manager` mutex; the lock is only held for the
+    /// `HashMap::remove` loop.
     ///
     /// # Errors
     ///
@@ -232,9 +244,11 @@ impl DeribitWebSocketClient {
 
         let response = self.send_request(request).await?;
 
-        {
+        // Parse + validate the confirmed list outside the subscription
+        // mutex. Only acquire the lock once we have work to do.
+        if let Some(confirmed) = confirmed_channels(&response, "public/unsubscribe")? {
             let mut sub_manager = self.subscription_manager.lock().await;
-            apply_unsubscribe_confirmation(&mut sub_manager, &response)?;
+            remove_confirmed_channels(&mut sub_manager, confirmed);
         }
 
         Ok(response)
@@ -1330,60 +1344,30 @@ impl Default for DeribitWebSocketClient {
     }
 }
 
-/// Apply a server-confirmed `public/subscribe` response to `manager`.
+/// Add a pre-parsed list of server-confirmed channels to `manager`.
 ///
-/// Parses the JSON array carried by `response.result` as a list of channel
-/// names and adds each to the manager. Deribit's response is the set of
-/// channels actually accepted by the server — a possible strict subset of
-/// the requested list when individual channels are rejected (unknown
-/// channel, permission denied, rate limit). Only this reconciled set
-/// appears in the local view; the caller's input list is never consulted.
-///
-/// API-error responses ([`JsonRpcResult::Error`]) are a no-op: the caller
-/// returns them verbatim so the error surface is visible to the caller.
-///
-/// # Errors
-///
-/// Returns [`WebSocketError::InvalidMessage`] when a `Success` response
-/// carries a `result` value that cannot be parsed as `Vec<String>`.
-fn apply_subscribe_confirmation(
-    manager: &mut SubscriptionManager,
-    response: &JsonRpcResponse,
-) -> Result<(), WebSocketError> {
-    let confirmed = match confirmed_channels(response, "public/subscribe")? {
-        Some(list) => list,
-        None => return Ok(()),
-    };
-    for channel in confirmed {
+/// Computes the typed [`SubscriptionChannel`] variant and the instrument
+/// token for each channel and records the subscription in the manager.
+/// The caller is expected to invoke this while holding the
+/// `subscription_manager` lock; parsing and validation of the raw
+/// response should happen outside the lock (via [`confirmed_channels`]).
+fn add_confirmed_channels(manager: &mut SubscriptionManager, channels: Vec<String>) {
+    for channel in channels {
         let channel_type = SubscriptionChannel::from_string(&channel);
         let instrument = instrument_from_channel(&channel);
         manager.add_subscription(channel, channel_type, instrument);
     }
-    Ok(())
 }
 
-/// Apply a server-confirmed `public/unsubscribe` response to `manager`.
+/// Remove a pre-parsed list of server-confirmed channels from `manager`.
 ///
-/// Mirror of [`apply_subscribe_confirmation`] for the unsubscribe path:
-/// only the channels the server actually unsubscribed are removed from the
-/// local view. API-error responses are a no-op.
-///
-/// # Errors
-///
-/// Returns [`WebSocketError::InvalidMessage`] when a `Success` response
-/// carries a `result` value that cannot be parsed as `Vec<String>`.
-fn apply_unsubscribe_confirmation(
-    manager: &mut SubscriptionManager,
-    response: &JsonRpcResponse,
-) -> Result<(), WebSocketError> {
-    let confirmed = match confirmed_channels(response, "public/unsubscribe")? {
-        Some(list) => list,
-        None => return Ok(()),
-    };
-    for channel in confirmed {
+/// The caller is expected to invoke this while holding the
+/// `subscription_manager` lock; parsing and validation of the raw
+/// response should happen outside the lock (via [`confirmed_channels`]).
+fn remove_confirmed_channels(manager: &mut SubscriptionManager, channels: Vec<String>) {
+    for channel in channels {
         manager.remove_subscription(&channel);
     }
-    Ok(())
 }
 
 /// Extract the confirmed channel list from a subscribe/unsubscribe response.
@@ -1447,8 +1431,8 @@ mod tests {
     //! Reconciliation tests for `subscribe` / `unsubscribe` (issue #62).
     //!
     //! The bulk are stubbed-response tests that drive the pure sync
-    //! helpers ([`apply_subscribe_confirmation`] /
-    //! [`apply_unsubscribe_confirmation`]) directly with hand-crafted
+    //! helpers ([`confirmed_channels`] / [`add_confirmed_channels`] /
+    //! [`remove_confirmed_channels`]) directly with hand-crafted
     //! [`JsonRpcResponse`] values and a bare [`SubscriptionManager`]. One
     //! end-to-end test stands up a mock WebSocket server and exercises
     //! the full [`DeribitWebSocketClient::subscribe`] path to prove the
@@ -1474,19 +1458,45 @@ mod tests {
         )
     }
 
+    /// Drive the same control flow that `subscribe()` uses: parse the
+    /// response outside the lock, then hand the confirmed list to the
+    /// mutator. Returns `Ok(())` on success (including API-error
+    /// responses, which are a deliberate no-op) and the parse error on
+    /// malformed `Success` responses.
+    fn reconcile_subscribe(
+        manager: &mut SubscriptionManager,
+        response: &JsonRpcResponse,
+    ) -> Result<(), WebSocketError> {
+        if let Some(confirmed) = confirmed_channels(response, "public/subscribe")? {
+            add_confirmed_channels(manager, confirmed);
+        }
+        Ok(())
+    }
+
+    /// Mirror of [`reconcile_subscribe`] for the unsubscribe path.
+    fn reconcile_unsubscribe(
+        manager: &mut SubscriptionManager,
+        response: &JsonRpcResponse,
+    ) -> Result<(), WebSocketError> {
+        if let Some(confirmed) = confirmed_channels(response, "public/unsubscribe")? {
+            remove_confirmed_channels(manager, confirmed);
+        }
+        Ok(())
+    }
+
     // ---------------------------------------------------------------
-    // Stubbed-response unit tests: apply_subscribe_confirmation
+    // Stubbed-response unit tests: subscribe reconciliation
     // ---------------------------------------------------------------
 
     #[test]
-    fn test_apply_subscribe_confirmation_adds_only_server_confirmed_channels() {
+    fn test_reconcile_subscribe_adds_only_server_confirmed_channels() {
         // Core acceptance criterion for issue #62: caller requested two
         // channels, server accepted only one. Local view must reflect
         // the server-confirmed subset — never the input.
         let mut manager = SubscriptionManager::new();
         let response = success(json!(["ticker.BTC-PERPETUAL"]));
 
-        apply_subscribe_confirmation(&mut manager, &response)
+        reconcile_subscribe(&mut manager, &response)
             .expect("well-formed success response reconciles");
 
         let channels = manager.get_all_channels();
@@ -1498,14 +1508,13 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_subscribe_confirmation_happy_path_input_equals_response() {
+    fn test_reconcile_subscribe_happy_path_input_equals_response() {
         // Regression guard: when the server confirms everything the
         // caller asked for, every requested channel lands in the manager.
         let mut manager = SubscriptionManager::new();
         let response = success(json!(["ticker.BTC-PERPETUAL", "book.ETH-PERPETUAL.raw"]));
 
-        apply_subscribe_confirmation(&mut manager, &response)
-            .expect("happy-path response reconciles");
+        reconcile_subscribe(&mut manager, &response).expect("happy-path response reconciles");
 
         let mut channels = manager.get_all_channels();
         channels.sort();
@@ -1524,19 +1533,19 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_subscribe_confirmation_empty_result_is_noop() {
+    fn test_reconcile_subscribe_empty_result_is_noop() {
         // Server accepted zero of the requested channels. The function
         // succeeds but makes no entries.
         let mut manager = SubscriptionManager::new();
         let response = success(json!([] as [&str; 0]));
 
-        apply_subscribe_confirmation(&mut manager, &response).expect("empty confirmation is valid");
+        reconcile_subscribe(&mut manager, &response).expect("empty confirmation is valid");
 
         assert!(manager.get_all_channels().is_empty());
     }
 
     #[test]
-    fn test_apply_subscribe_confirmation_api_error_is_noop() {
+    fn test_reconcile_subscribe_api_error_is_noop() {
         // API-error responses are surfaced to the caller verbatim and
         // must leave the local view untouched so the caller can retry.
         let mut manager = SubscriptionManager::new();
@@ -1548,7 +1557,12 @@ mod tests {
         let before = manager.get_all_channels();
         let response = api_error(-32000, "subscription rejected");
 
-        apply_subscribe_confirmation(&mut manager, &response)
+        // Must resolve to Ok(None) — no mutation attempted.
+        assert!(
+            matches!(confirmed_channels(&response, "public/subscribe"), Ok(None)),
+            "api-error response must yield Ok(None)"
+        );
+        reconcile_subscribe(&mut manager, &response)
             .expect("api-error response must not return Err");
 
         assert_eq!(
@@ -1559,14 +1573,14 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_subscribe_confirmation_non_array_result_returns_invalid_message() {
+    fn test_reconcile_subscribe_non_array_result_returns_invalid_message() {
         // A `Success` whose `result` is not an array of strings is a
         // protocol violation — we surface it as `InvalidMessage` rather
         // than silently skipping reconciliation.
         let mut manager = SubscriptionManager::new();
         let response = success(json!({ "channels": ["ticker.BTC-PERPETUAL"] }));
 
-        let err = apply_subscribe_confirmation(&mut manager, &response)
+        let err = reconcile_subscribe(&mut manager, &response)
             .expect_err("object result must not parse as Vec<String>");
         assert!(
             matches!(err, WebSocketError::InvalidMessage(_)),
@@ -1580,11 +1594,11 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Stubbed-response unit tests: apply_unsubscribe_confirmation
+    // Stubbed-response unit tests: unsubscribe reconciliation
     // ---------------------------------------------------------------
 
     #[test]
-    fn test_apply_unsubscribe_confirmation_removes_only_server_confirmed_channels() {
+    fn test_reconcile_unsubscribe_removes_only_server_confirmed_channels() {
         // Mirror of the subscribe subset test: two channels live in the
         // manager; the server confirms only one was unsubscribed. The
         // other must stay.
@@ -1601,7 +1615,7 @@ mod tests {
         );
         let response = success(json!(["ticker.BTC-PERPETUAL"]));
 
-        apply_unsubscribe_confirmation(&mut manager, &response)
+        reconcile_unsubscribe(&mut manager, &response)
             .expect("well-formed unsubscribe response reconciles");
 
         let channels = manager.get_all_channels();
@@ -1609,7 +1623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_unsubscribe_confirmation_happy_path() {
+    fn test_reconcile_unsubscribe_happy_path() {
         // Regression guard: server confirms everything the caller asked
         // to drop; the manager ends empty.
         let mut manager = SubscriptionManager::new();
@@ -1625,14 +1639,13 @@ mod tests {
         );
         let response = success(json!(["ticker.BTC-PERPETUAL", "book.ETH-PERPETUAL.raw"]));
 
-        apply_unsubscribe_confirmation(&mut manager, &response)
-            .expect("happy-path unsubscribe reconciles");
+        reconcile_unsubscribe(&mut manager, &response).expect("happy-path unsubscribe reconciles");
 
         assert!(manager.get_all_channels().is_empty());
     }
 
     #[test]
-    fn test_apply_unsubscribe_confirmation_api_error_is_noop() {
+    fn test_reconcile_unsubscribe_api_error_is_noop() {
         let mut manager = SubscriptionManager::new();
         manager.add_subscription(
             "ticker.BTC-PERPETUAL".to_string(),
@@ -1642,7 +1655,7 @@ mod tests {
         let before = manager.get_all_channels();
         let response = api_error(-32000, "unsubscribe rejected");
 
-        apply_unsubscribe_confirmation(&mut manager, &response)
+        reconcile_unsubscribe(&mut manager, &response)
             .expect("api-error response must not return Err");
 
         assert_eq!(
@@ -1653,7 +1666,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_unsubscribe_confirmation_non_array_result_returns_invalid_message() {
+    fn test_reconcile_unsubscribe_non_array_result_returns_invalid_message() {
         let mut manager = SubscriptionManager::new();
         manager.add_subscription(
             "ticker.BTC-PERPETUAL".to_string(),
@@ -1662,7 +1675,7 @@ mod tests {
         );
         let response = success(json!("not an array"));
 
-        let err = apply_unsubscribe_confirmation(&mut manager, &response)
+        let err = reconcile_unsubscribe(&mut manager, &response)
             .expect_err("string result must not parse as Vec<String>");
         assert!(
             matches!(err, WebSocketError::InvalidMessage(_)),

--- a/tests/unit/client.rs
+++ b/tests/unit/client.rs
@@ -95,32 +95,46 @@ fn test_client_debug() {
 
 #[test]
 fn test_client_parse_channel_type() {
-    let config = WebSocketConfig::default();
-    let _client = DeribitWebSocketClient::new(&config).unwrap();
+    // `SubscriptionChannel::from_string` is the sole parser used by the
+    // client's subscribe/unsubscribe reconciliation, so pin its behaviour
+    // for the channel formats the client ingests most frequently.
+    use deribit_websocket::model::SubscriptionChannel;
 
-    // Test channel parsing through subscription management
-    // This is an indirect test since parse_channel_type is private
-    let subscriptions = [
-        "ticker.BTC-PERPETUAL".to_string(),
-        "book.ETH-PERPETUAL.100ms".to_string(),
-        "trades.BTC-PERPETUAL".to_string(),
-    ];
-
-    // The client should be able to handle these channel formats
-    assert!(subscriptions.iter().all(|s| !s.is_empty()));
+    assert_eq!(
+        SubscriptionChannel::from_string("ticker.BTC-PERPETUAL"),
+        SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string())
+    );
+    assert_eq!(
+        SubscriptionChannel::from_string("book.ETH-PERPETUAL.raw"),
+        SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string())
+    );
+    assert_eq!(
+        SubscriptionChannel::from_string("trades.BTC-PERPETUAL.raw"),
+        SubscriptionChannel::Trades("BTC-PERPETUAL".to_string())
+    );
+    // Unknown channels round-trip through the catch-all variant.
+    assert!(SubscriptionChannel::from_string("totally.unknown.channel").is_unknown());
 }
 
 #[test]
 fn test_client_extract_instrument() {
-    let config = WebSocketConfig::default();
-    let _client = DeribitWebSocketClient::new(&config).unwrap();
+    // The canonical round-trip: build a channel from its typed variant and
+    // confirm the same string re-parses to the same variant. Keeps the
+    // instrument extraction honest against drift in either direction.
+    use deribit_websocket::model::SubscriptionChannel;
 
-    // Test instrument extraction through subscription management
-    let channels = [
-        "ticker.BTC-PERPETUAL".to_string(),
-        "book.ETH-PERPETUAL.100ms".to_string(),
-    ];
-
-    // The client should be able to handle instrument extraction
-    assert!(channels.iter().all(|s| s.contains('.')));
+    for original in [
+        SubscriptionChannel::Ticker("BTC-PERPETUAL".to_string()),
+        SubscriptionChannel::OrderBook("ETH-PERPETUAL".to_string()),
+        SubscriptionChannel::Trades("BTC-PERPETUAL".to_string()),
+        SubscriptionChannel::Quote("SOL-PERPETUAL".to_string()),
+    ] {
+        let channel_name = original.channel_name();
+        let reparsed = SubscriptionChannel::from_string(&channel_name);
+        assert_eq!(
+            original, reparsed,
+            "channel {} must survive a round-trip through from_string",
+            channel_name
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #62. `subscribe()` and `unsubscribe()` previously iterated the caller's input `Vec<String>` and mutated the local `SubscriptionManager` accordingly on a `Success` response. Deribit's `public/subscribe` / `public/unsubscribe` responses carry an array of the channels the server **actually** accepted or unsubscribed — a possible strict subset of the requested list when individual channels are rejected (unknown channel, permission denied, rate limit). The old path silently over-reported the local view.

Reconciliation now runs off the server-confirmed list.

## Changes

- **`src/client.rs`** — new private helpers `apply_subscribe_confirmation` and `apply_unsubscribe_confirmation` parse `response.result` as `Vec<String>` and drive the `SubscriptionManager` mutation off the server-confirmed list. Protocol violations (e.g. `result` is not an array of strings) now surface as `WebSocketError::InvalidMessage`, consistent with `authenticate`, `get_time`, etc. API-error responses remain a no-op: the caller returns them verbatim so the embedded error is visible.
- **`src/client.rs`** — `subscribe()` and `unsubscribe()` delegate to the new helpers; the redundant `channels.clone()` is gone and the tight lock scope around `subscription_manager` (established in PR #61) is preserved. Doc comments updated: drop the "not yet reconciled — see follow-up issue" TODO, state the new semantics, add `# Errors` sections.
- **`src/client.rs`** — removed dead private methods `parse_channel_type` and `extract_instrument` from `DeribitWebSocketClient`. The reconciliation helpers call `SubscriptionChannel::from_string` and a new `instrument_from_channel` free function directly, so they can be unit-tested without a client instance.
- **`tests/unit/client.rs`** — the pre-existing `test_client_parse_channel_type` and `test_client_extract_instrument` were placeholder tests that built a client and asserted string trivia without calling anything. Repurposed them to actually exercise `SubscriptionChannel::from_string` and its `channel_name` round-trip.

## Technical Decisions

- **Pure sync helpers, not methods.** `apply_*_confirmation` take `&mut SubscriptionManager` and `&JsonRpcResponse` — no `self`, no client. Makes every reconciliation path unit-testable with hand-crafted responses and a bare manager, zero async/network plumbing for the 9 pure tests.
- **Parse failure returns `InvalidMessage`, not silent no-op.** A `Success` response whose `result` is not an array of strings is a protocol violation. Treating it as "no-op, return Ok" would let a malformed server response silently desync the local view. Matches the parse-error convention used elsewhere in `client.rs`.
- **One end-to-end mock-server test + 9 stubbed-response tests** (user-approved strategy from planning). The mock-server test proves the exact issue acceptance criterion through the full `DeribitWebSocketClient::subscribe` pipeline. The stubbed tests pin every corner of the reconciliation logic cheaply and deterministically.

## Testing

- [x] Unit tests added/updated — 9 new stubbed-response tests + 2 upgraded placeholder tests in `tests/unit/client.rs`
- [x] Integration tests added/updated — 1 new end-to-end mock-server test in `src/client.rs #[cfg(test)]`
- [ ] Benchmark tests added/updated (not applicable)
- [x] Manual testing performed via `make pre-push` — **58 lib + 430 integration + 5 doc = 493 tests passing**, 0 failing. Lib-test delta: 48 → 58 (exactly the 10 new tests).

## Acceptance criteria (from issue)

- [x] `client.subscribe(vec!["ticker.INVALID", "ticker.BTC-PERPETUAL"])` against a mock server returning `["ticker.BTC-PERPETUAL"]` leaves only `BTC-PERPETUAL` in the local manager — `test_subscribe_reconciles_local_state_with_server_subset`.
- [x] Unit test with a stubbed response verifying the subset semantics — `test_apply_subscribe_confirmation_adds_only_server_confirmed_channels`.
- [x] No regression in the happy-path test (input equals response) — `test_apply_subscribe_confirmation_happy_path_input_equals_response` + `test_apply_unsubscribe_confirmation_happy_path`.

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code (only in tests, as permitted)
- [x] WebSocket connection lifecycle handled (no changes to connect/disconnect; subscribe/unsubscribe still respect the PR #61 lock discipline)
- [x] Minimal dependencies — no new crates added

Closes #62
