### PR TITLE
#50: Bound connect_async handshake by connection_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,10 @@ builder methods or the corresponding environment variables:
 
 - **`connection_timeout`** (default 10s, env `DERIBIT_CONNECTION_TIMEOUT`) —
   upper bound on the WebSocket handshake (TCP + TLS + HTTP upgrade).
-  A peer that accepts the TCP connection but never completes the
-  upgrade makes `connect()` fail with `WebSocketError::Timeout`
-  instead of hanging.
+  For APIs that honor this setting, such as
+  `DeribitWebSocketClient::connect`, a peer that accepts the TCP
+  connection but never completes the upgrade makes the connect call
+  fail with `WebSocketError::Timeout` instead of hanging.
 - **`request_timeout`** (default 30s, env `DERIBIT_REQUEST_TIMEOUT`) —
   upper bound on each `send_request` call, covering enqueue, write,
   and response wait. On the deadline the dispatcher evicts the

--- a/README.md
+++ b/README.md
@@ -167,6 +167,26 @@ The crate includes comprehensive examples demonstrating:
 - **`mass_quote_advanced.rs`** - Advanced mass quoting with multiple MMP groups
 - **`mass_quote_options.rs`** - Options-specific mass quoting with delta management
 
+### Timeouts
+
+Two deadlines bound the most common sources of indefinite hangs in a
+network client. Both live on `WebSocketConfig` and can be set via
+builder methods or the corresponding environment variables:
+
+- **`connection_timeout`** (default 10s, env `DERIBIT_CONNECTION_TIMEOUT`) —
+  upper bound on the WebSocket handshake (TCP + TLS + HTTP upgrade).
+  A peer that accepts the TCP connection but never completes the
+  upgrade makes `connect()` fail with `WebSocketError::Timeout`
+  instead of hanging.
+- **`request_timeout`** (default 30s, env `DERIBIT_REQUEST_TIMEOUT`) —
+  upper bound on each `send_request` call, covering enqueue, write,
+  and response wait. On the deadline the dispatcher evicts the
+  now-orphaned waiter so the id-map stays small under repeated
+  timeouts.
+
+Planned follow-ups: `read_idle_timeout` (maximum gap between frames)
+and granular per-operation overrides.
+
 ### Architecture
 
 The client is built with a modular architecture:

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,6 +103,7 @@ impl DeribitWebSocketClient {
         }
         let dispatcher = Dispatcher::connect(
             self.config.ws_url.clone(),
+            self.config.connection_timeout,
             self.config.request_timeout,
             self.config.notification_channel_capacity,
             self.config.dispatcher_command_capacity,

--- a/src/connection/dispatcher.rs
+++ b/src/connection/dispatcher.rs
@@ -81,8 +81,9 @@ impl Dispatcher {
     /// notifications.
     ///
     /// The WebSocket handshake (`connect_async`) is bounded by
-    /// `connection_timeout`: a stalled TCP or TLS handshake fails fast
-    /// with [`WebSocketError::Timeout`] instead of hanging indefinitely.
+    /// `connection_timeout`: a stalled handshake (TCP + TLS + HTTP
+    /// upgrade) fails fast with [`WebSocketError::Timeout`] instead of
+    /// hanging indefinitely.
     ///
     /// # Arguments
     ///

--- a/src/connection/dispatcher.rs
+++ b/src/connection/dispatcher.rs
@@ -80,9 +80,16 @@ impl Dispatcher {
     /// dispatcher task that services JSON-RPC requests and forwards
     /// notifications.
     ///
+    /// The WebSocket handshake (`connect_async`) is bounded by
+    /// `connection_timeout`: a stalled TCP or TLS handshake fails fast
+    /// with [`WebSocketError::Timeout`] instead of hanging indefinitely.
+    ///
     /// # Arguments
     ///
     /// - `url` — WebSocket URL to connect to.
+    /// - `connection_timeout` — upper bound on the `connect_async`
+    ///   handshake (TCP + TLS + HTTP upgrade). Exceeded means the peer
+    ///   never completed the upgrade.
     /// - `request_timeout` — upper bound for each `send_request` call.
     /// - `notification_capacity` — depth of the bounded notifications
     ///   channel. Slow consumers apply back-pressure on the dispatcher.
@@ -90,16 +97,27 @@ impl Dispatcher {
     ///
     /// # Errors
     ///
-    /// Returns [`WebSocketError::ConnectionFailed`] if the underlying
-    /// `connect_async` handshake fails.
+    /// - [`WebSocketError::Timeout`] if the handshake does not complete
+    ///   within `connection_timeout`.
+    /// - [`WebSocketError::ConnectionFailed`] if the underlying
+    ///   `connect_async` handshake returns an error (DNS, TCP refused,
+    ///   TLS failure, bad upgrade response, etc.).
     pub async fn connect(
         url: Url,
+        connection_timeout: Duration,
         request_timeout: Duration,
         notification_capacity: usize,
         cmd_capacity: usize,
     ) -> Result<Self, WebSocketError> {
-        let (stream, _response) = connect_async(url.as_str())
+        let handshake = tokio::time::timeout(connection_timeout, connect_async(url.as_str()))
             .await
+            .map_err(|_| {
+                WebSocketError::Timeout(format!(
+                    "connection_timeout {:?} elapsed during handshake",
+                    connection_timeout
+                ))
+            })?;
+        let (stream, _response) = handshake
             .map_err(|e| WebSocketError::ConnectionFailed(format!("Failed to connect: {}", e)))?;
         let (sink, stream) = stream.split();
         let (cmd_tx, cmd_rx) = mpsc::channel::<DispatcherCommand>(cmd_capacity);
@@ -411,9 +429,15 @@ mod tests {
         })
         .await;
 
-        let dispatcher = Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 16, 16)
-            .await
-            .expect("dispatcher connects");
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            16,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
         let response = dispatcher
             .send_request(make_request(42, "public/test"))
             .await
@@ -437,9 +461,15 @@ mod tests {
         })
         .await;
 
-        let dispatcher = Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 16, 16)
-            .await
-            .expect("dispatcher connects");
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            16,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
         let text = tokio::time::timeout(Duration::from_secs(2), dispatcher.next_notification())
             .await
             .expect("notification arrives within timeout")
@@ -483,9 +513,15 @@ mod tests {
         .await;
 
         let dispatcher = Arc::new(
-            Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 16, 16)
-                .await
-                .expect("dispatcher connects"),
+            Dispatcher::connect(
+                ws_url(addr),
+                Duration::from_secs(5),
+                Duration::from_secs(5),
+                16,
+                16,
+            )
+            .await
+            .expect("dispatcher connects"),
         );
 
         let mut handles = Vec::new();
@@ -556,9 +592,15 @@ mod tests {
         // Use a generous notification buffer so we don't stall on the 100
         // burst while the consumer is still spinning up.
         let dispatcher = Arc::new(
-            Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 512, 16)
-                .await
-                .expect("dispatcher connects"),
+            Dispatcher::connect(
+                ws_url(addr),
+                Duration::from_secs(5),
+                Duration::from_secs(5),
+                512,
+                16,
+            )
+            .await
+            .expect("dispatcher connects"),
         );
 
         // Drain notifications concurrently.
@@ -632,9 +674,15 @@ mod tests {
         })
         .await;
 
-        let dispatcher = Dispatcher::connect(ws_url(addr), Duration::from_millis(200), 16, 16)
-            .await
-            .expect("dispatcher connects");
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_millis(200),
+            16,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
         let start = std::time::Instant::now();
         let result = dispatcher
             .send_request(make_request(7, "public/test"))
@@ -665,9 +713,15 @@ mod tests {
         })
         .await;
 
-        let dispatcher = Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 16, 16)
-            .await
-            .expect("dispatcher connects");
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            16,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
         let result = dispatcher
             .send_request(make_request(99, "public/test"))
             .await;
@@ -712,9 +766,15 @@ mod tests {
         })
         .await;
 
-        let dispatcher = Dispatcher::connect(ws_url(addr), Duration::from_millis(100), 16, 16)
-            .await
-            .expect("dispatcher connects");
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_millis(100),
+            16,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
         let result = dispatcher
             .send_request(make_request(7, "public/test"))
             .await;
@@ -770,9 +830,15 @@ mod tests {
         .await;
 
         let dispatcher = Arc::new(
-            Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 16, 16)
-                .await
-                .expect("dispatcher connects"),
+            Dispatcher::connect(
+                ws_url(addr),
+                Duration::from_secs(5),
+                Duration::from_secs(5),
+                16,
+                16,
+            )
+            .await
+            .expect("dispatcher connects"),
         );
 
         // Spawn the first request; it parks until the server replies.
@@ -822,9 +888,15 @@ mod tests {
         })
         .await;
 
-        let dispatcher = Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 16, 16)
-            .await
-            .expect("dispatcher connects");
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            16,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
         let text = tokio::time::timeout(Duration::from_secs(2), dispatcher.next_notification())
             .await
             .expect("unmatched id arrives within timeout")
@@ -883,9 +955,15 @@ mod tests {
         .await;
 
         let dispatcher = Arc::new(
-            Dispatcher::connect(ws_url(addr), Duration::from_secs(5), 64, 64)
-                .await
-                .expect("dispatcher connects"),
+            Dispatcher::connect(
+                ws_url(addr),
+                Duration::from_secs(5),
+                Duration::from_secs(5),
+                64,
+                64,
+            )
+            .await
+            .expect("dispatcher connects"),
         );
 
         let start = std::time::Instant::now();

--- a/src/connection/dispatcher.rs
+++ b/src/connection/dispatcher.rs
@@ -410,6 +410,79 @@ mod tests {
         }
     }
 
+    /// Spawn a TCP listener that accepts one connection at the raw TCP
+    /// layer and then holds the socket without performing the WebSocket
+    /// upgrade. From the client's point of view the TCP connect
+    /// succeeds but the HTTP/WebSocket handshake never completes, which
+    /// is the stall mode `connection_timeout` must defend against.
+    ///
+    /// The returned [`JoinHandle`] owns the socket for the lifetime of
+    /// the test and should be aborted when the test is done.
+    async fn spawn_stalled_handshake_listener() -> (SocketAddr, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind localhost ephemeral port");
+        let addr = listener
+            .local_addr()
+            .expect("read local addr of bound listener");
+        let handle = tokio::spawn(async move {
+            if let Ok((socket, _peer)) = listener.accept().await {
+                // Hold the socket well past any realistic test deadline.
+                // The test aborts this task before it ever wakes up.
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                drop(socket);
+            }
+        });
+        (addr, handle)
+    }
+
+    /// Regression test for issue #50: if the peer accepts the TCP
+    /// connection but never completes the WebSocket upgrade, `connect`
+    /// must fail fast with `WebSocketError::Timeout` within the
+    /// configured `connection_timeout`.
+    #[tokio::test]
+    async fn test_connect_times_out_when_handshake_stalls() {
+        let (addr, server) = spawn_stalled_handshake_listener().await;
+        let url = ws_url(addr);
+
+        let start = std::time::Instant::now();
+        let result = Dispatcher::connect(
+            url,
+            Duration::from_millis(100),
+            Duration::from_secs(5),
+            16,
+            16,
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(result, Err(WebSocketError::Timeout(_))),
+            "stalled handshake must surface WebSocketError::Timeout, got {:?}",
+            result
+        );
+        // 5x headroom over the 100ms deadline to tolerate CI scheduler jitter.
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "connect must return within 500ms of a 100ms connection_timeout, took {:?}",
+            elapsed
+        );
+        if let Err(WebSocketError::Timeout(msg)) = result {
+            assert!(
+                msg.contains("handshake"),
+                "error message should mention the handshake, got: {}",
+                msg
+            );
+            assert!(
+                msg.contains("connection_timeout"),
+                "error message should name the config field, got: {}",
+                msg
+            );
+        }
+
+        server.abort();
+    }
+
     #[tokio::test]
     async fn test_dispatch_matches_single_request_response_by_id() {
         let (addr, server) = spawn_mock_server(|mut sink, mut stream| async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,8 @@
 //! - **`connection_timeout`** (default 10s, env `DERIBIT_CONNECTION_TIMEOUT`) —
 //!   upper bound on the WebSocket handshake (TCP + TLS + HTTP upgrade).
 //!   A peer that accepts the TCP connection but never completes the
-//!   upgrade makes `connect()` fail with `WebSocketError::Timeout`
-//!   instead of hanging.
+//!   upgrade makes `DeribitWebSocketClient::connect` / `Dispatcher::connect`
+//!   fail with `WebSocketError::Timeout` instead of hanging.
 //! - **`request_timeout`** (default 30s, env `DERIBIT_REQUEST_TIMEOUT`) —
 //!   upper bound on each `send_request` call, covering enqueue, write,
 //!   and response wait. On the deadline the dispatcher evicts the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,26 @@
 //! - **`mass_quote_advanced.rs`** - Advanced mass quoting with multiple MMP groups
 //! - **`mass_quote_options.rs`** - Options-specific mass quoting with delta management
 //!
+//! ## Timeouts
+//!
+//! Two deadlines bound the most common sources of indefinite hangs in a
+//! network client. Both live on `WebSocketConfig` and can be set via
+//! builder methods or the corresponding environment variables:
+//!
+//! - **`connection_timeout`** (default 10s, env `DERIBIT_CONNECTION_TIMEOUT`) —
+//!   upper bound on the WebSocket handshake (TCP + TLS + HTTP upgrade).
+//!   A peer that accepts the TCP connection but never completes the
+//!   upgrade makes `connect()` fail with `WebSocketError::Timeout`
+//!   instead of hanging.
+//! - **`request_timeout`** (default 30s, env `DERIBIT_REQUEST_TIMEOUT`) —
+//!   upper bound on each `send_request` call, covering enqueue, write,
+//!   and response wait. On the deadline the dispatcher evicts the
+//!   now-orphaned waiter so the id-map stays small under repeated
+//!   timeouts.
+//!
+//! Planned follow-ups: `read_idle_timeout` (maximum gap between frames)
+//! and granular per-operation overrides.
+//!
 //! ## Architecture
 //!
 //! The client is built with a modular architecture:

--- a/tests/unit/client.rs
+++ b/tests/unit/client.rs
@@ -116,6 +116,53 @@ fn test_client_parse_channel_type() {
     assert!(SubscriptionChannel::from_string("totally.unknown.channel").is_unknown());
 }
 
+#[tokio::test]
+async fn test_client_connect_honors_connection_timeout() {
+    // Defends the wiring of WebSocketConfig::connection_timeout into
+    // Dispatcher::connect from a positional-arg swap regression: a stalled
+    // peer must surface as Timeout within roughly the configured deadline,
+    // not hang. Uses a TcpListener that accepts but never responds, so
+    // connect_async sits in the HTTP upgrade phase until the deadline.
+    use deribit_websocket::error::WebSocketError;
+    use std::time::Duration;
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral localhost port");
+    let addr = listener.local_addr().expect("read local addr");
+
+    // Keep the listener alive in a task that accepts but never reads/writes,
+    // so the client's TCP handshake completes but the WS upgrade never does.
+    let _server = tokio::spawn(async move {
+        if let Ok((socket, _)) = listener.accept().await {
+            // Hold the socket open beyond the client's deadline.
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            drop(socket);
+        }
+    });
+
+    let config = WebSocketConfig::with_url(&format!("ws://{}/", addr))
+        .expect("valid ws url")
+        .with_connection_timeout(Duration::from_millis(150));
+    let client = DeribitWebSocketClient::new(&config).expect("client constructs");
+
+    let start = std::time::Instant::now();
+    let result = client.connect().await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        matches!(result, Err(WebSocketError::Timeout(_))),
+        "expected Timeout from stalled handshake, got {:?}",
+        result
+    );
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "timeout should fire near 150ms, elapsed = {:?}",
+        elapsed
+    );
+}
+
 #[test]
 fn test_client_extract_instrument() {
     // The canonical round-trip: build a channel from its typed variant and


### PR DESCRIPTION
## Summary

Wires the existing `WebSocketConfig::connection_timeout` field into the production I/O site so that a stalled WebSocket handshake fails fast with `WebSocketError::Timeout` instead of hanging indefinitely. Prior to this change, the field was populated from env/defaults and readable via `with_connection_timeout` but was never actually consumed — `Dispatcher::connect` called `connect_async` with no deadline, and a misbehaving peer that completed TCP but never responded to the HTTP upgrade could hang the caller forever. Defers the granular `read_idle_timeout` and per-op overrides to a follow-up as the issue explicitly proposes.

## Changes

- **`Dispatcher::connect` signature**: adds `connection_timeout: Duration` as the second positional argument (before `request_timeout`, mirroring the chronological order of the two deadlines in the connection lifecycle).
- **Handshake wrap**: `connect_async(url.as_str())` is now wrapped by `tokio::time::timeout(connection_timeout, ...)`. Elapsed deadline returns `WebSocketError::Timeout(_)` with a message naming both the operation (`handshake`) and the config field (`connection_timeout`). DNS/TCP-refused/TLS-error paths continue to surface `WebSocketError::ConnectionFailed` unchanged.
- **`DeribitWebSocketClient::connect`**: passes `self.config.connection_timeout` through to `Dispatcher::connect`. The config field finally has a reader at an I/O site.
- **Regression test**: `test_connect_times_out_when_handshake_stalls` in `src/connection/dispatcher.rs` spawns a TCP listener that accepts one connection but never calls `accept_async`, asserts the client returns `Err(WebSocketError::Timeout(_))` within a 100ms deadline + 500ms wall-clock (5x CI-jitter headroom), and verifies the error message contains both `handshake` and `connection_timeout`.
- **Existing dispatcher tests**: the 10 pre-existing `#[tokio::test]` call sites of `Dispatcher::connect` pass a generous `Duration::from_secs(5)` as the new handshake bound so happy-path coverage stays insensitive to the new deadline.
- **Crate docs**: new `## Timeouts` section in `src/lib.rs` documents which operation each active timeout covers (`connection_timeout` → handshake, `request_timeout` → per-`send_request` wait) and calls out the planned `read_idle_timeout` follow-up. `README.md` regenerated via `cargo readme`.

## Technical Decisions

- **Breaking signature change to `Dispatcher::connect`.** Accepted because `Dispatcher` is re-exported as `crate::connection::Dispatcher` but not via the prelude, and its primary consumer is `DeribitWebSocketClient::connect`. The crate is pre-1.0 (0.2.x) and the issue itself endorses a two-PR split that necessarily touches this signature.
- **Reused the existing `connection_timeout` field** instead of introducing a new `connect_timeout`, per the issue's own guidance: *"keep `connection_timeout`, add two more in a second PR."*
- **Error variant reuse.** `WebSocketError::Timeout(String)` already existed for the `send_request` path; reused it for the handshake path with a descriptive message naming the operation and config field so operators can tell the two deadlines apart in logs.
- **Argument ordering.** Placed `connection_timeout` before `request_timeout` to match the chronological order of the two deadlines. Makes call sites read naturally as a connection lifecycle.
- **Legacy `WebSocketConnection` type left untouched.** It is `pub` and re-exported via the prelude, but nothing in `src/` calls it — the production data path is `Client → Dispatcher → connect_async`. Deferring its timeout story (if needed) to a future issue avoids touching a legacy public surface inside a targeted fix.

## Testing

- [x] Unit tests added/updated — 1 new (`test_connect_times_out_when_handshake_stalls`), 10 existing dispatcher tests updated to pass the new argument.
- [x] Integration tests added/updated — none needed; change is internal to the connection lifecycle and the unit test covers the stall mode deterministically against a local TCP listener.
- [ ] Benchmark tests added/updated — n/a.
- [x] Manual testing performed (`cargo test --all-features`). Full suite: **59 lib + 430 integration + 5 doc = 494 passing, 0 failed** (22 live-network integration tests in `tests/integration/**` require `.env.backup` credentials and are environment-dependent; identical behaviour on `main`).

Acceptance criteria from issue #50:
- `rg 'connection_timeout|connect_timeout|request_timeout|read_idle_timeout' src/` shows `connection_timeout` read at `src/connection/dispatcher.rs` inside the `connect_async` wrapper.
- Stalled-mock-server unit test returns `WebSocketError::Timeout` within `connection_timeout + 400ms` tolerance (5× headroom on a 100ms deadline).
- README (generated from `src/lib.rs`) documents which operation each active timeout covers.

## Checklist

- [x] All public items have `///` documentation (new rustdoc on `Dispatcher::connect` explains the `connection_timeout` arg and the new `WebSocketError::Timeout` error path).
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings` (5 pre-existing `rustdoc::private_intra_doc_links` warnings in `config.rs` are unrelated to this PR and present on `main`).
- [x] `cargo fmt --all --check` passes.
- [x] No `.unwrap()`, `.expect()`, or panics in library code (new code uses `?` + `map_err`; `.expect()` calls are all inside `#[cfg(test)]` blocks).
- [x] WebSocket connection lifecycle handled (the deadline covers the exact I/O site that was previously unbounded; on timeout the `connect_async` future is dropped, freeing the half-open socket).
- [x] Minimal dependencies — no new crates added.

Closes #50
