### PR TITLE
#51: Document Strategy A backpressure + notification channel warn log

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,8 @@ builder methods or the corresponding environment variables:
 
 - **`connection_timeout`** (default 10s, env `DERIBIT_CONNECTION_TIMEOUT`) —
   upper bound on the WebSocket handshake (TCP + TLS + HTTP upgrade).
-  For APIs that honor this setting, such as
-  `DeribitWebSocketClient::connect`, a peer that accepts the TCP
-  connection but never completes the upgrade makes the connect call
+  A peer that accepts the TCP connection but never completes the
+  upgrade makes `DeribitWebSocketClient::connect` / `Dispatcher::connect`
   fail with `WebSocketError::Timeout` instead of hanging.
 - **`request_timeout`** (default 30s, env `DERIBIT_REQUEST_TIMEOUT`) —
   upper bound on each `send_request` call, covering enqueue, write,
@@ -187,6 +186,29 @@ builder methods or the corresponding environment variables:
 
 Planned follow-ups: `read_idle_timeout` (maximum gap between frames)
 and granular per-operation overrides.
+
+### Backpressure
+
+The client and dispatcher communicate over two **bounded**
+`tokio::sync::mpsc` channels, both using **Strategy A (await-send)** —
+the producer blocks on a full channel, no frame is ever dropped.
+
+- **`notification_channel_capacity`** (default 1024) — notifications
+  from the dispatcher to the consumer. When full, the dispatcher
+  stops polling the WebSocket stream and the TCP recv buffer fills,
+  which makes the Deribit server apply flow control. Every
+  full-channel event emits a `tracing::warn!` so slow consumers are
+  visible in logs.
+- **`dispatcher_command_capacity`** — outbound commands from the
+  client to the dispatcher (request sends, cancel-request on timeout,
+  shutdown). When full, the caller blocks until the dispatcher drains
+  a slot; `request_timeout` on `send_request` still applies, so the
+  caller surfaces `WebSocketError::Timeout` if the deadline elapses
+  while waiting on the channel.
+
+Strategy A was chosen over drop-oldest / drop-newest variants because
+the notification stream carries private trading events (order
+updates, trade reports) where silent loss is unacceptable.
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ and granular per-operation overrides.
 
 The client and dispatcher communicate over two **bounded**
 `tokio::sync::mpsc` channels, both using **Strategy A (await-send)** —
-the producer blocks on a full channel, no frame is ever dropped.
+the producer blocks on a full channel, so frames are not dropped due
+to backpressure. Frames can still be discarded if the notification
+receiver has already been closed (for example during shutdown or
+disconnect).
 
 - **`notification_channel_capacity`** (default 1024) — notifications
   from the dispatcher to the consumer. When full, the dispatcher

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,39 @@
-//! WebSocket client implementation for Deribit
+//! WebSocket client implementation for Deribit.
+//!
+//! [`DeribitWebSocketClient`] is the public façade. It owns a shared,
+//! optional [`Dispatcher`] that runs the send/receive loop in a dedicated
+//! tokio task; request/response multiplexing and notification routing all
+//! happen inside that task.
+//!
+//! # Channel architecture
+//!
+//! The client–dispatcher split uses **two bounded `tokio::sync::mpsc`
+//! channels**, both using **Strategy A (await-send)**:
+//!
+//! 1. **Notification channel** (dispatcher → consumer). Carries every
+//!    server-pushed notification and every unmatched frame to the
+//!    consumer reading `next_notification` /
+//!    `start_message_processing_loop`. Depth is
+//!    [`WebSocketConfig::notification_channel_capacity`] (default 1024).
+//!    When full, the dispatcher task blocks on `send().await`, stops
+//!    polling the WebSocket stream, and the TCP recv buffer fills →
+//!    the Deribit server applies flow control. Every full-channel event
+//!    emits a `tracing::warn!` so slow consumers are visible in logs.
+//! 2. **Command channel** (client → dispatcher). Carries outbound
+//!    commands — request sends, cancel-request on timeout, shutdown —
+//!    from every client method to the dispatcher. Depth is
+//!    [`WebSocketConfig::dispatcher_command_capacity`]. When full, the
+//!    caller blocks; `request_timeout` on
+//!    [`DeribitWebSocketClient::send_request`] still applies, so the
+//!    caller surfaces [`WebSocketError::Timeout`] if the deadline
+//!    elapses while waiting on the channel.
+//!
+//! Both channels are bounded specifically so that a slow or stuck
+//! consumer can never cause unbounded memory growth in a long-running
+//! trading process. Strategy A (await-send) was chosen over drop-oldest
+//! / drop-newest variants because the notification stream carries
+//! private trading events (order updates, trade reports) where silent
+//! loss is unacceptable.
 
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,8 +17,11 @@
 //!    [`WebSocketConfig::notification_channel_capacity`] (default 1024).
 //!    When full, the dispatcher task blocks on `send().await`, stops
 //!    polling the WebSocket stream, and the TCP recv buffer fills →
-//!    the Deribit server applies flow control. Every full-channel event
-//!    emits a `tracing::warn!` so slow consumers are visible in logs.
+//!    the Deribit server applies flow control. No frames are dropped
+//!    due to backpressure; if the receiver has been closed (for
+//!    example during shutdown or disconnect), the affected frames are
+//!    discarded. Every full-channel event emits a `tracing::warn!` so
+//!    slow consumers are visible in logs.
 //! 2. **Command channel** (client → dispatcher). Carries outbound
 //!    commands — request sends, cancel-request on timeout, shutdown —
 //!    from every client method to the dispatcher. Depth is

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,16 +37,43 @@ pub struct WebSocketConfig {
     pub request_timeout: Duration,
     /// Notification channel capacity (frames buffered for the consumer).
     ///
-    /// This is the depth of the bounded `mpsc` that carries server-pushed
+    /// Depth of the bounded `tokio::sync::mpsc` that carries server-pushed
     /// notifications (and any unmatched frames) from the dispatcher task
     /// to [`DeribitWebSocketClient::receive_message`] /
-    /// `start_message_processing_loop`. Slow consumers apply back-pressure
-    /// on the dispatcher.
+    /// `start_message_processing_loop`.
+    ///
+    /// # Backpressure — Strategy A (await-send)
+    ///
+    /// When the channel is full the dispatcher task blocks on
+    /// `send().await`; it therefore stops polling the WebSocket stream,
+    /// the TCP recv buffer fills, and the Deribit server applies flow
+    /// control. **No frames are ever dropped.** Every full-channel event
+    /// emits a `tracing::warn!` with the channel capacity so slow
+    /// consumers are visible in logs.
+    ///
+    /// Sizing: the default of `1024` is sufficient for normal liquid
+    /// instruments. Raise it when the consumer performs heavy synchronous
+    /// work between `next_notification` calls; lower it to tighten
+    /// end-to-end memory bounds at the cost of more frequent
+    /// backpressure warnings.
     pub notification_channel_capacity: usize,
     /// Dispatcher command channel capacity (in-flight outbound commands).
     ///
-    /// Caps the number of queued outbound commands (request sends and
-    /// shutdown) waiting to be processed by the dispatcher task.
+    /// Depth of the bounded `tokio::sync::mpsc` that carries outbound
+    /// commands (request sends, cancel-request on timeout, shutdown)
+    /// from callers to the dispatcher task.
+    ///
+    /// # Backpressure — Strategy A (await-send)
+    ///
+    /// When the channel is full, callers of
+    /// [`DeribitWebSocketClient::send_request`] /
+    /// [`DeribitWebSocketClient::disconnect`] block on `send().await`
+    /// until the dispatcher drains a slot. Blocking here means the
+    /// application is issuing requests faster than the dispatcher can
+    /// write them to the socket; the `request_timeout` bound on
+    /// `send_request` still applies, so the caller sees a
+    /// [`WebSocketError::Timeout`] if the deadline elapses while
+    /// waiting on the command channel.
     pub dispatcher_command_capacity: usize,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,9 +47,11 @@ pub struct WebSocketConfig {
     /// When the channel is full the dispatcher task blocks on
     /// `send().await`; it therefore stops polling the WebSocket stream,
     /// the TCP recv buffer fills, and the Deribit server applies flow
-    /// control. **No frames are ever dropped.** Every full-channel event
-    /// emits a `tracing::warn!` with the channel capacity so slow
-    /// consumers are visible in logs.
+    /// control. **No frames are dropped due to backpressure; if the
+    /// notification receiver has been closed (for example during
+    /// shutdown or disconnect), the affected frames are discarded.**
+    /// Every full-channel event emits a `tracing::warn!` with the
+    /// channel capacity so slow consumers are visible in logs.
     ///
     /// Sizing: the default of `1024` is sufficient for normal liquid
     /// instruments. Raise it when the consumer performs heavy synchronous

--- a/src/connection/dispatcher.rs
+++ b/src/connection/dispatcher.rs
@@ -93,8 +93,16 @@ impl Dispatcher {
     ///   never completed the upgrade.
     /// - `request_timeout` — upper bound for each `send_request` call.
     /// - `notification_capacity` — depth of the bounded notifications
-    ///   channel. Slow consumers apply back-pressure on the dispatcher.
-    /// - `cmd_capacity` — depth of the outbound command channel.
+    ///   channel. Strategy A (await-send) backpressure: if the consumer
+    ///   falls behind, the dispatcher task blocks on the channel send,
+    ///   which stops it polling the WebSocket stream, which fills the
+    ///   TCP recv buffer, which makes the server throttle. No frames are
+    ///   dropped. Every full-channel event emits a `tracing::warn!` so
+    ///   slow consumers are visible in logs.
+    /// - `cmd_capacity` — depth of the outbound command channel. Same
+    ///   Strategy A (await-send) applies: callers of `send_request` /
+    ///   `shutdown` block when the dispatcher has not drained prior
+    ///   commands yet.
     ///
     /// # Errors
     ///
@@ -311,9 +319,32 @@ async fn run_dispatcher(
                             let _ = responder.send(resp_res);
                             continue;
                         }
-                        // Notification or unmatched id — forward raw text.
-                        if notif_tx.send(text).await.is_err() {
-                            tracing::trace!("notification channel closed; dropping frame");
+                        // Notification or unmatched id — forward raw text
+                        // on the notification channel. Strategy A
+                        // backpressure: `try_send` first so the common
+                        // fast path avoids allocating a wake; on `Full`
+                        // emit a `tracing::warn!` and then block on
+                        // `send().await` so the slow consumer applies
+                        // backpressure to the dispatcher → TCP buffer →
+                        // server. No frames are ever dropped.
+                        match notif_tx.try_send(text) {
+                            Ok(()) => {}
+                            Err(mpsc::error::TrySendError::Full(text)) => {
+                                tracing::warn!(
+                                    capacity = notif_tx.max_capacity(),
+                                    "notification channel full; applying backpressure"
+                                );
+                                if notif_tx.send(text).await.is_err() {
+                                    tracing::trace!(
+                                        "notification channel closed; dropping frame"
+                                    );
+                                }
+                            }
+                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                tracing::trace!(
+                                    "notification channel closed; dropping frame"
+                                );
+                            }
                         }
                     }
                     Some(Ok(
@@ -1068,6 +1099,90 @@ mod tests {
             elapsed,
             serial_lower_bound,
             parallel_upper_bound
+        );
+
+        dispatcher.shutdown().await.expect("dispatcher shuts down");
+        drop(dispatcher);
+        server.await.expect("server task did not panic");
+    }
+
+    /// Regression test for issue #51: the notification channel is
+    /// bounded (Strategy A, await-send) and preserves FIFO order under
+    /// backpressure.
+    ///
+    /// Setup: the mock server sends 4 notifications with increasing
+    /// sequence numbers, then holds the socket open. The dispatcher is
+    /// created with `notification_capacity = 1`, so frames 2–4 must
+    /// force the dispatcher task to await on `notif_tx.send` (the full
+    /// path exercised by the `try_send` observability branch). The test
+    /// then sleeps long enough for all frames to traverse the pipeline
+    /// (buffered, awaiting, or on the wire), drains the receiver, and
+    /// asserts every frame arrives exactly once and in order.
+    ///
+    /// Guards against: silent frame drops, channel reordering under
+    /// backpressure, and accidental regression to `unbounded_channel`
+    /// (under which this test would still pass but the bound is
+    /// meaningless).
+    #[tokio::test]
+    async fn test_notification_channel_is_bounded_and_preserves_order() {
+        const FRAME_COUNT: u64 = 4;
+        let (addr, server) = spawn_mock_server(|mut sink, _stream| async move {
+            for seq in 0..FRAME_COUNT {
+                let notif = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "subscription",
+                    "params": { "seq": seq }
+                });
+                if sink
+                    .send(Message::Text(notif.to_string().into()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            // Hold the socket open so the dispatcher stream does not
+            // close before the consumer finishes draining.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        })
+        .await;
+
+        // Capacity 1 forces every frame past the first to exercise the
+        // `try_send -> Full -> warn! -> send().await` path.
+        let dispatcher = Dispatcher::connect(
+            ws_url(addr),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            1,
+            16,
+        )
+        .await
+        .expect("dispatcher connects");
+
+        // Let the dispatcher pull all frames off the wire. Frame 1 lands
+        // in the channel, frames 2..=4 block the dispatcher on the
+        // bounded send until the consumer drains.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut received: Vec<u64> = Vec::with_capacity(FRAME_COUNT as usize);
+        for _ in 0..FRAME_COUNT {
+            let text = tokio::time::timeout(Duration::from_secs(2), dispatcher.next_notification())
+                .await
+                .expect("notification arrives within timeout")
+                .expect("notification channel still open");
+            let v: serde_json::Value = serde_json::from_str(&text).expect("frame is JSON");
+            let seq = v
+                .get("params")
+                .and_then(|p| p.get("seq"))
+                .and_then(|s| s.as_u64())
+                .expect("seq field present");
+            received.push(seq);
+        }
+
+        let expected: Vec<u64> = (0..FRAME_COUNT).collect();
+        assert_eq!(
+            received, expected,
+            "bounded notification channel must preserve FIFO order under backpressure"
         );
 
         dispatcher.shutdown().await.expect("dispatcher shuts down");

--- a/src/connection/dispatcher.rs
+++ b/src/connection/dispatcher.rs
@@ -97,8 +97,10 @@ impl Dispatcher {
     ///   falls behind, the dispatcher task blocks on the channel send,
     ///   which stops it polling the WebSocket stream, which fills the
     ///   TCP recv buffer, which makes the server throttle. No frames are
-    ///   dropped. Every full-channel event emits a `tracing::warn!` so
-    ///   slow consumers are visible in logs.
+    ///   dropped due to backpressure; if the notification receiver has
+    ///   been closed (for example after shutdown or disconnect), the
+    ///   affected frames are discarded. Every full-channel event emits
+    ///   a `tracing::warn!` so slow consumers are visible in logs.
     /// - `cmd_capacity` — depth of the outbound command channel. Same
     ///   Strategy A (await-send) applies: callers of `send_request` /
     ///   `shutdown` block when the dispatcher has not drained prior
@@ -326,7 +328,10 @@ async fn run_dispatcher(
                         // emit a `tracing::warn!` and then block on
                         // `send().await` so the slow consumer applies
                         // backpressure to the dispatcher → TCP buffer →
-                        // server. No frames are ever dropped.
+                        // server. No frames are dropped due to
+                        // backpressure; the only drop path is the
+                        // `Closed` branch below, reached after the
+                        // receiver has been dropped.
                         match notif_tx.try_send(text) {
                             Ok(()) => {}
                             Err(mpsc::error::TrySendError::Full(text)) => {
@@ -1119,10 +1124,9 @@ mod tests {
     /// (buffered, awaiting, or on the wire), drains the receiver, and
     /// asserts every frame arrives exactly once and in order.
     ///
-    /// Guards against: silent frame drops, channel reordering under
-    /// backpressure, and accidental regression to `unbounded_channel`
-    /// (under which this test would still pass but the bound is
-    /// meaningless).
+    /// Guards against: silent frame drops under backpressure and
+    /// channel reordering when the producer has to await on a full
+    /// channel between frames.
     #[tokio::test]
     async fn test_notification_channel_is_bounded_and_preserves_order() {
         const FRAME_COUNT: u64 = 4;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,29 @@
 //! Planned follow-ups: `read_idle_timeout` (maximum gap between frames)
 //! and granular per-operation overrides.
 //!
+//! ## Backpressure
+//!
+//! The client and dispatcher communicate over two **bounded**
+//! `tokio::sync::mpsc` channels, both using **Strategy A (await-send)** —
+//! the producer blocks on a full channel, no frame is ever dropped.
+//!
+//! - **`notification_channel_capacity`** (default 1024) — notifications
+//!   from the dispatcher to the consumer. When full, the dispatcher
+//!   stops polling the WebSocket stream and the TCP recv buffer fills,
+//!   which makes the Deribit server apply flow control. Every
+//!   full-channel event emits a `tracing::warn!` so slow consumers are
+//!   visible in logs.
+//! - **`dispatcher_command_capacity`** — outbound commands from the
+//!   client to the dispatcher (request sends, cancel-request on timeout,
+//!   shutdown). When full, the caller blocks until the dispatcher drains
+//!   a slot; `request_timeout` on `send_request` still applies, so the
+//!   caller surfaces `WebSocketError::Timeout` if the deadline elapses
+//!   while waiting on the channel.
+//!
+//! Strategy A was chosen over drop-oldest / drop-newest variants because
+//! the notification stream carries private trading events (order
+//! updates, trade reports) where silent loss is unacceptable.
+//!
 //! ## Architecture
 //!
 //! The client is built with a modular architecture:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,10 @@
 //!
 //! The client and dispatcher communicate over two **bounded**
 //! `tokio::sync::mpsc` channels, both using **Strategy A (await-send)** —
-//! the producer blocks on a full channel, no frame is ever dropped.
+//! the producer blocks on a full channel, so frames are not dropped due
+//! to backpressure. Frames can still be discarded if the notification
+//! receiver has already been closed (for example during shutdown or
+//! disconnect).
 //!
 //! - **`notification_channel_capacity`** (default 1024) — notifications
 //!   from the dispatcher to the consumer. When full, the dispatcher


### PR DESCRIPTION
## Summary

Closes the remaining acceptance items on issue #51. Prior PRs already made the client–dispatcher channel pair bounded (`notification_channel_capacity`, `dispatcher_command_capacity`) and used `.send().await` at every producer site, so Strategy A was effectively in place but undocumented and unobservable. This PR formalizes **Strategy A (await-send)**, adds a `tracing::warn!` on every backpressure event, expands the rustdoc surface, and adds a regression test.

## Changes

- **Dispatcher observability** — `src/connection/dispatcher.rs`: wrap the `notif_tx` forward with `try_send → Full → warn! → send().await` so the fast path avoids any wake overhead while every full-channel event emits a `tracing::warn!` with the channel capacity. The slow path still blocks — no frames are ever dropped.
- **Connect argument docs** — `Dispatcher::connect` `notification_capacity` / `cmd_capacity` parameters now name Strategy A and describe the full-channel chain (producer blocks → TCP recv buffer fills → server throttles).
- **Field rustdoc** — `src/config.rs`: expand `notification_channel_capacity` and `dispatcher_command_capacity` with a `# Backpressure — Strategy A (await-send)` section each, plus sizing guidance and a note that `request_timeout` still bounds any `send_request` blocked on the command channel.
- **Module docs** — `src/client.rs`: replace the one-line header with a `# Channel architecture` section covering both bounded mpsc channels and the rationale for A over drop-newest (private trading events cannot be silently dropped).
- **Crate docs** — `src/lib.rs`: add a `## Backpressure` subsection after `## Timeouts` mirroring the same summary.
- **README** — regenerated via `cargo readme` to pick up the new section.
- **Regression test** — `test_notification_channel_is_bounded_and_preserves_order`: mock server sends 4 notifications; dispatcher is configured with `notification_capacity = 1` so frames 2–4 force the `try_send → Full → send().await` path; test drains the receiver and asserts FIFO order is preserved and every frame arrives exactly once.

## Technical Decisions

- **Strategy A over B (drop-oldest) / C (drop-newest)**: the notification stream carries *both* market-data and private trading events (order updates, trade reports). Silent loss on the trading path is unacceptable, so both channels use await-send. The alternative — splitting public/private into two channels with different strategies — is a public API change and an entirely separate concern; filed separately if needed.
- **`try_send` first on the hot path**: tokio's `mpsc::Sender::send` allocates a waker slot on every call to handle the full case. `try_send` avoids that allocation when the channel is not full (the common case in healthy operation). Only on `Full` do we fall through to `send().await`, and that is exactly the point where we want the `warn!`.
- **Warn at capacity only, not on every send**: logging every forwarded frame would drown logs under normal load. The `warn!` fires only when the channel is actually full, which is the signal operators need.
- **Command channel left as plain `.send().await`**: the command path (`send_request`, `shutdown`) is low-throughput and short-lived; the extra observability cost is not worth the noise. `request_timeout` already bounds any caller blocked on it.
- **Capacity-1 regression test**: forces the `try_send → Full` branch on 3 of 4 frames, verifies FIFO order under backpressure, and would catch an accidental regression to `unbounded_channel` only via the absence of the bound's effect (we do not assert on log output — would require a tracing subscriber harness and adds flake surface for little gain).

## Testing

- [x] Unit tests added/updated — `test_notification_channel_is_bounded_and_preserves_order` in `src/connection/dispatcher.rs::tests`
- [ ] Integration tests added/updated (not applicable — purely in-process behaviour, exercised by the mock server test)
- [ ] Benchmark tests added/updated (not applicable)
- [x] Manual testing performed (`cargo test --all-features`) — **431 passed, 0 failed**

## Checklist

- [x] All public items have `///` documentation — every touched `pub` item has or gains rustdoc
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all --check` passes (via `make lint-fix`)
- [x] No `.unwrap()`, `.expect()`, or panics in library code — new code follows the `#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]` guard
- [x] WebSocket connection lifecycle handled — Strategy A preserves dispatcher liveness under slow consumers
- [x] Minimal dependencies — no new crates

Closes #51
