### PR TITLE
#53: Add mock-server integration test suite

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,20 @@
+//! Integration tests against a local mock WebSocket server.
+//!
+//! These tests are self-contained: they spawn a `tokio-tungstenite`
+//! server bound to `127.0.0.1:0`, wire a `DeribitWebSocketClient` to
+//! that ephemeral port, and exercise the public client API without
+//! touching the real Deribit service. No credentials or network access
+//! required.
+//!
+//! Covers the flows listed in issue #53: auth, subscribe/unsubscribe,
+//! notification delivery, reconnect, request/response id matching, and
+//! timeout handling.
+//!
+//! Run with `cargo test --test integration`.
+
+// Integration tests routinely use `.unwrap()` / `.expect()` for brevity
+// and to surface failures with clear panic messages. Silence the strict
+// lints that are enforced on the library crate here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod integration_mock;

--- a/tests/integration_mock/auth.rs
+++ b/tests/integration_mock/auth.rs
@@ -56,4 +56,7 @@ async fn authenticate_round_trip_against_mock() {
     })
     .await
     .expect("auth flow finishes within 5s");
+
+    // Surface any panic from the server scenario closure.
+    server.finish().await;
 }

--- a/tests/integration_mock/auth.rs
+++ b/tests/integration_mock/auth.rs
@@ -1,0 +1,59 @@
+//! Authentication flow against the mock server.
+//!
+//! Verifies that `DeribitWebSocketClient::authenticate` sends a
+//! `public/auth` JSON-RPC request, that the returned `AuthResponse` is
+//! parsed from the server reply, and that the whole round-trip
+//! completes without panics.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+
+use super::helpers::client::mock_client;
+use super::helpers::frames::auth_success;
+use super::helpers::mock_server::spawn_mock_server;
+
+#[tokio::test]
+async fn authenticate_round_trip_against_mock() {
+    let server = spawn_mock_server(|mut sink, mut stream| async move {
+        // Read the single `public/auth` request and reply with a canned
+        // AuthResponse carrying the id the client assigned.
+        if let Some(Ok(Message::Text(text))) = stream.next().await {
+            let request: Value = serde_json::from_str(&text).expect("auth request parses as JSON");
+            assert_eq!(
+                request["method"], "public/auth",
+                "first frame must be public/auth, got {}",
+                request["method"]
+            );
+            let id = request.get("id").cloned().unwrap_or(Value::Null);
+            let _ = sink.send(Message::Text(auth_success(&id).into())).await;
+        }
+        // Keep the sink alive briefly so the client can read the reply.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    })
+    .await;
+
+    let client = mock_client(&server);
+
+    timeout(Duration::from_secs(5), async {
+        client.connect().await.expect("connect succeeds");
+
+        let auth = client
+            .authenticate("mock-id", "mock-secret")
+            .await
+            .expect("authenticate succeeds");
+
+        assert_eq!(auth.access_token, "mock-access-token");
+        assert_eq!(auth.token_type, "bearer");
+        assert_eq!(auth.expires_in, 900);
+        assert_eq!(auth.refresh_token, "mock-refresh-token");
+        assert_eq!(auth.scope, "session:mock");
+
+        client.disconnect().await.expect("disconnect succeeds");
+    })
+    .await
+    .expect("auth flow finishes within 5s");
+}

--- a/tests/integration_mock/helpers/client.rs
+++ b/tests/integration_mock/helpers/client.rs
@@ -1,0 +1,27 @@
+//! Build a `DeribitWebSocketClient` wired to a [`MockServer`].
+//!
+//! The configuration uses tight timeouts so tests fail fast when
+//! something hangs, and disables logging so test output stays clean.
+
+use std::time::Duration;
+
+use deribit_websocket::prelude::*;
+
+use super::mock_server::MockServer;
+
+/// Build a [`WebSocketConfig`] pointing at `server` with deterministic,
+/// tight timeouts and logging disabled. Callers that need different
+/// timeouts (for example the request-timeout test) should chain
+/// additional `with_*` calls on the returned value.
+pub(crate) fn mock_config(server: &MockServer) -> WebSocketConfig {
+    WebSocketConfig::with_url(&server.ws_url())
+        .expect("mock server URL parses")
+        .with_connection_timeout(Duration::from_millis(500))
+        .with_request_timeout(Duration::from_secs(2))
+        .with_logging(false)
+}
+
+/// Build a [`DeribitWebSocketClient`] using [`mock_config`].
+pub(crate) fn mock_client(server: &MockServer) -> DeribitWebSocketClient {
+    DeribitWebSocketClient::new(&mock_config(server)).expect("client construction succeeds")
+}

--- a/tests/integration_mock/helpers/frames.rs
+++ b/tests/integration_mock/helpers/frames.rs
@@ -1,0 +1,76 @@
+//! JSON-RPC frame constructors for mock scenarios.
+//!
+//! Each helper returns the serialised JSON payload ready to wrap in a
+//! `tokio_tungstenite::tungstenite::Message::Text`. The `id` is passed
+//! in as a borrowed [`serde_json::Value`] so the scenario can echo back
+//! whatever the client sent, preserving the JSON-RPC id-correlation
+//! semantics the tests exercise.
+
+use serde_json::{Value, json};
+
+/// Build a `{jsonrpc, id, result}` success response.
+pub(crate) fn response(id: &Value, result: Value) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    })
+    .to_string()
+}
+
+/// Build a canned `public/auth` success response matching
+/// [`deribit_websocket::model::AuthResponse`].
+pub(crate) fn auth_success(id: &Value) -> String {
+    response(
+        id,
+        json!({
+            "access_token": "mock-access-token",
+            "token_type": "bearer",
+            "expires_in": 900,
+            "refresh_token": "mock-refresh-token",
+            "scope": "session:mock",
+        }),
+    )
+}
+
+/// Build a `public/subscribe` success response: JSON array of the
+/// channels the server confirmed.
+pub(crate) fn subscribe_success(id: &Value, channels: &[&str]) -> String {
+    let arr: Vec<Value> = channels
+        .iter()
+        .map(|c| Value::String((*c).to_owned()))
+        .collect();
+    response(id, Value::Array(arr))
+}
+
+/// Build a `public/unsubscribe` success response: identical shape to
+/// [`subscribe_success`].
+pub(crate) fn unsubscribe_success(id: &Value, channels: &[&str]) -> String {
+    subscribe_success(id, channels)
+}
+
+/// Build a server-pushed `subscription` notification for `channel`
+/// with a small, deterministic ticker-like payload.
+pub(crate) fn ticker_notification(channel: &str) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "method": "subscription",
+        "params": {
+            "channel": channel,
+            "data": {
+                "instrument_name": "BTC-PERPETUAL",
+                "best_bid_price": 50000.0,
+                "best_ask_price": 50001.0,
+                "timestamp": 1_700_000_000_000_u64,
+            },
+        },
+    })
+    .to_string()
+}
+
+/// Build a `{jsonrpc, id, result}` frame carrying a plain integer
+/// result, used by the id-matching test where the mock echoes the
+/// request id scaled by 1000 so each response is distinguishable.
+pub(crate) fn u64_result(id: &Value, value: u64) -> String {
+    response(id, json!(value))
+}

--- a/tests/integration_mock/helpers/mock_server.rs
+++ b/tests/integration_mock/helpers/mock_server.rs
@@ -1,0 +1,133 @@
+//! Local `tokio-tungstenite` WebSocket server used by the mock
+//! integration tests.
+//!
+//! Each test spawns a server on `127.0.0.1:0`, hands the split
+//! sink/stream to a scenario closure, and the scenario drives the
+//! conversation (reads the client's request, replies with canned
+//! frames, optionally closes the socket). The returned [`MockServer`]
+//! aborts the background task on `Drop` so tests cannot leak server
+//! tasks between runs.
+
+use std::future::Future;
+use std::net::SocketAddr;
+
+use futures_util::StreamExt;
+use futures_util::stream::{SplitSink, SplitStream};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+/// Sink half of the mock server's WebSocket stream passed to scenarios.
+pub(crate) type ScenarioSink = SplitSink<WebSocketStream<tokio::net::TcpStream>, Message>;
+
+/// Stream half of the mock server's WebSocket stream passed to scenarios.
+pub(crate) type ScenarioStream = SplitStream<WebSocketStream<tokio::net::TcpStream>>;
+
+/// Handle to a running mock server.
+///
+/// The background task is aborted on `Drop`, so tests that create a
+/// [`MockServer`] must keep it alive for the duration of the assertions
+/// they care about. The [`MockServer::ws_url`] helper returns the
+/// `ws://127.0.0.1:<port>/` URL the client should dial.
+pub(crate) struct MockServer {
+    /// Address the listener is bound to.
+    pub(crate) addr: SocketAddr,
+    handle: JoinHandle<()>,
+}
+
+impl MockServer {
+    /// Return the URL a client should use to connect to this server.
+    pub(crate) fn ws_url(&self) -> String {
+        format!("ws://{}/", self.addr)
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// Spawn a local WebSocket server that accepts a single connection and
+/// runs `scenario` against the split sink/stream.
+///
+/// The listener binds `127.0.0.1:0` so the OS picks a free port,
+/// making parallel test execution safe. Any error during `accept` or
+/// the WebSocket handshake silently terminates the task: tests assert
+/// through the client side, not the server side, so the server simply
+/// goes away on errors.
+pub(crate) async fn spawn_mock_server<F, Fut>(scenario: F) -> MockServer
+where
+    F: FnOnce(ScenarioSink, ScenarioStream) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send,
+{
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind localhost ephemeral port");
+    let addr = listener
+        .local_addr()
+        .expect("read local addr of bound listener");
+    let handle = tokio::spawn(async move {
+        let (socket, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let ws = match accept_async(socket).await {
+            Ok(ws) => ws,
+            Err(_) => return,
+        };
+        let (sink, stream) = ws.split();
+        scenario(sink, stream).await;
+    });
+    MockServer { addr, handle }
+}
+
+/// Spawn a local WebSocket server that accepts exactly two connections
+/// in sequence, running `first` against the first accept and `second`
+/// against the second.
+///
+/// Used by the reconnect test: the first scenario closes the socket,
+/// the client then calls `connect()` again, and the listener accepts
+/// the new handshake for the second scenario.
+pub(crate) async fn spawn_mock_server_twice<F1, Fut1, F2, Fut2>(first: F1, second: F2) -> MockServer
+where
+    F1: FnOnce(ScenarioSink, ScenarioStream) -> Fut1 + Send + 'static,
+    Fut1: Future<Output = ()> + Send,
+    F2: FnOnce(ScenarioSink, ScenarioStream) -> Fut2 + Send + 'static,
+    Fut2: Future<Output = ()> + Send,
+{
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind localhost ephemeral port");
+    let addr = listener
+        .local_addr()
+        .expect("read local addr of bound listener");
+    let handle = tokio::spawn(async move {
+        // First accept.
+        let (socket, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let ws = match accept_async(socket).await {
+            Ok(ws) => ws,
+            Err(_) => return,
+        };
+        let (sink, stream) = ws.split();
+        first(sink, stream).await;
+
+        // Second accept.
+        let (socket, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let ws = match accept_async(socket).await {
+            Ok(ws) => ws,
+            Err(_) => return,
+        };
+        let (sink, stream) = ws.split();
+        second(sink, stream).await;
+    });
+    MockServer { addr, handle }
+}

--- a/tests/integration_mock/helpers/mock_server.rs
+++ b/tests/integration_mock/helpers/mock_server.rs
@@ -27,14 +27,21 @@ pub(crate) type ScenarioStream = SplitStream<WebSocketStream<tokio::net::TcpStre
 
 /// Handle to a running mock server.
 ///
-/// The background task is aborted on `Drop`, so tests that create a
-/// [`MockServer`] must keep it alive for the duration of the assertions
-/// they care about. The [`MockServer::ws_url`] helper returns the
+/// Tests should call [`MockServer::finish`] once the client side is
+/// done so a server-side panic (for example, an assertion failure
+/// inside a scenario closure) is surfaced as a test failure rather
+/// than silently swallowed by `tokio::spawn`. The background task is
+/// still aborted on `Drop` as a safety net for tests that exit early
+/// via `?` or panic before reaching the `finish` call.
+///
+/// The [`MockServer::ws_url`] helper returns the
 /// `ws://127.0.0.1:<port>/` URL the client should dial.
 pub(crate) struct MockServer {
     /// Address the listener is bound to.
     pub(crate) addr: SocketAddr,
-    handle: JoinHandle<()>,
+    /// Wrapped in `Option` so [`finish`] can take ownership of the
+    /// handle without racing the `Drop` abort fallback.
+    handle: Option<JoinHandle<()>>,
 }
 
 impl MockServer {
@@ -42,11 +49,35 @@ impl MockServer {
     pub(crate) fn ws_url(&self) -> String {
         format!("ws://{}/", self.addr)
     }
+
+    /// Await the server task and propagate any panic from a scenario
+    /// closure into the calling test.
+    ///
+    /// Panics raised inside `tokio::spawn` are only observable when the
+    /// corresponding [`JoinHandle`] is awaited; without this call a
+    /// server-side `assert!`/`expect` failure would be silently
+    /// dropped and the client-side assertions could pass, masking a
+    /// real bug in the mock scenario or in the code under test.
+    ///
+    /// Cancellation (the `Drop` abort fallback) is treated as a no-op
+    /// so tests that exit early still shut down cleanly.
+    pub(crate) async fn finish(mut self) {
+        if let Some(handle) = self.handle.take() {
+            match handle.await {
+                Ok(()) => {}
+                Err(err) if err.is_cancelled() => {}
+                Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+                Err(err) => panic!("mock server task failed: {err:?}"),
+            }
+        }
+    }
 }
 
 impl Drop for MockServer {
     fn drop(&mut self) {
-        self.handle.abort();
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -81,7 +112,10 @@ where
         let (sink, stream) = ws.split();
         scenario(sink, stream).await;
     });
-    MockServer { addr, handle }
+    MockServer {
+        addr,
+        handle: Some(handle),
+    }
 }
 
 /// Spawn a local WebSocket server that accepts exactly two connections
@@ -129,5 +163,8 @@ where
         let (sink, stream) = ws.split();
         second(sink, stream).await;
     });
-    MockServer { addr, handle }
+    MockServer {
+        addr,
+        handle: Some(handle),
+    }
 }

--- a/tests/integration_mock/helpers/mod.rs
+++ b/tests/integration_mock/helpers/mod.rs
@@ -1,0 +1,12 @@
+//! Shared helpers for the mock-server integration tests.
+//!
+//! - [`mock_server`] spawns a local `tokio-tungstenite` server bound to
+//!   an ephemeral port.
+//! - [`client`] builds a `DeribitWebSocketClient` wired to that server
+//!   with deterministic, tight timeouts suitable for tests.
+//! - [`frames`] constructs the JSON-RPC payloads the mock scenarios
+//!   reply with.
+
+pub(crate) mod client;
+pub(crate) mod frames;
+pub(crate) mod mock_server;

--- a/tests/integration_mock/id_matching.rs
+++ b/tests/integration_mock/id_matching.rs
@@ -1,0 +1,93 @@
+//! Concurrent request/response id matching against the mock server.
+//!
+//! Spawns three concurrent [`DeribitWebSocketClient::get_time`] calls
+//! and has the mock reply in REVERSE order to prove that the
+//! dispatcher's id-correlation does not depend on response ordering —
+//! each caller's future must resolve to the value keyed by the id it
+//! sent, never another caller's result.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+
+use super::helpers::client::mock_client;
+use super::helpers::frames::u64_result;
+use super::helpers::mock_server::spawn_mock_server;
+
+const CONCURRENT_REQUESTS: usize = 3;
+
+/// Per-request marker the mock multiplies the request id by, producing
+/// a distinct response value per id.
+const RESULT_MULTIPLIER: u64 = 1_000;
+
+#[tokio::test]
+async fn concurrent_requests_match_responses_by_id() {
+    let server = spawn_mock_server(|mut sink, mut stream| async move {
+        // Read all N requests before sending any reply, then flush them
+        // back in reverse order. The reverse flush is what proves id
+        // matching is not order-dependent.
+        let mut requests: Vec<Value> = Vec::with_capacity(CONCURRENT_REQUESTS);
+        for _ in 0..CONCURRENT_REQUESTS {
+            match stream.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    let v: Value = serde_json::from_str(&text).expect("request parses as JSON");
+                    requests.push(v);
+                }
+                _ => return,
+            }
+        }
+        for request in requests.into_iter().rev() {
+            let id = request.get("id").cloned().unwrap_or(Value::Null);
+            let id_num = id.as_u64().unwrap_or(0);
+            let value = id_num.saturating_mul(RESULT_MULTIPLIER);
+            let _ = sink
+                .send(Message::Text(u64_result(&id, value).into()))
+                .await;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    })
+    .await;
+
+    let client = Arc::new(mock_client(&server));
+
+    timeout(Duration::from_secs(5), async {
+        client.connect().await.expect("connect");
+
+        let mut handles = Vec::with_capacity(CONCURRENT_REQUESTS);
+        for _ in 0..CONCURRENT_REQUESTS {
+            let c = Arc::clone(&client);
+            handles.push(tokio::spawn(async move { c.get_time().await }));
+        }
+
+        let mut results: Vec<u64> = Vec::with_capacity(CONCURRENT_REQUESTS);
+        for handle in handles {
+            let value = handle
+                .await
+                .expect("task did not panic")
+                .expect("get_time succeeds");
+            results.push(value);
+        }
+
+        // Each request got id N (N >= 1), and the mock replies with
+        // N * RESULT_MULTIPLIER. After collection, the set of results
+        // must be exactly {N * MULT for N in 1..=CONCURRENT_REQUESTS}
+        // regardless of the order the tasks finished.
+        results.sort_unstable();
+        let expected: Vec<u64> = (1..=CONCURRENT_REQUESTS as u64)
+            .map(|i| i.saturating_mul(RESULT_MULTIPLIER))
+            .collect();
+        assert_eq!(
+            results, expected,
+            "concurrent requests must resolve to their own ids: got {:?}, expected {:?}",
+            results, expected
+        );
+
+        client.disconnect().await.expect("disconnect");
+    })
+    .await
+    .expect("id-matching flow finishes within 5s");
+}

--- a/tests/integration_mock/id_matching.rs
+++ b/tests/integration_mock/id_matching.rs
@@ -90,4 +90,6 @@ async fn concurrent_requests_match_responses_by_id() {
     })
     .await
     .expect("id-matching flow finishes within 5s");
+
+    server.finish().await;
 }

--- a/tests/integration_mock/mod.rs
+++ b/tests/integration_mock/mod.rs
@@ -1,0 +1,13 @@
+//! Mock-server integration test modules.
+//!
+//! Each submodule exercises one flow from issue #53 against the shared
+//! mock server and client helpers in [`helpers`].
+
+pub(crate) mod helpers;
+
+mod auth;
+mod id_matching;
+mod notifications;
+mod reconnect;
+mod subscriptions;
+mod timeout;

--- a/tests/integration_mock/notifications.rs
+++ b/tests/integration_mock/notifications.rs
@@ -1,0 +1,68 @@
+//! Server-pushed notification delivery through
+//! [`DeribitWebSocketClient::receive_message`].
+//!
+//! The mock accepts a subscribe, replies success, then pushes a
+//! `subscription`-method notification. The client must surface that
+//! raw frame text on the next `receive_message` call.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+
+use super::helpers::client::mock_client;
+use super::helpers::frames::{subscribe_success, ticker_notification};
+use super::helpers::mock_server::spawn_mock_server;
+
+const CHANNEL: &str = "ticker.BTC-PERPETUAL.raw";
+
+#[tokio::test]
+async fn server_push_reaches_receive_message() {
+    let server = spawn_mock_server(|mut sink, mut stream| async move {
+        // Handle the subscribe then push one notification.
+        if let Some(Ok(Message::Text(text))) = stream.next().await {
+            let request: Value = serde_json::from_str(&text).expect("subscribe request parses");
+            let id = request.get("id").cloned().unwrap_or(Value::Null);
+            let _ = sink
+                .send(Message::Text(subscribe_success(&id, &[CHANNEL]).into()))
+                .await;
+        }
+        let _ = sink
+            .send(Message::Text(ticker_notification(CHANNEL).into()))
+            .await;
+        // Hold the socket open long enough for the client to pull the
+        // notification out of the mpsc channel.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    })
+    .await;
+
+    let client = mock_client(&server);
+
+    timeout(Duration::from_secs(5), async {
+        client.connect().await.expect("connect");
+        client
+            .subscribe(vec![CHANNEL.to_string()])
+            .await
+            .expect("subscribe");
+
+        let raw = client
+            .receive_message()
+            .await
+            .expect("notification arrives");
+        let parsed: Value = serde_json::from_str(&raw).expect("notification parses as JSON");
+
+        assert_eq!(parsed["method"], "subscription");
+        assert_eq!(parsed["params"]["channel"], CHANNEL);
+        assert!(
+            parsed["params"]["data"].is_object(),
+            "data must be present, got {}",
+            parsed["params"]["data"]
+        );
+
+        client.disconnect().await.expect("disconnect");
+    })
+    .await
+    .expect("notification flow finishes within 5s");
+}

--- a/tests/integration_mock/notifications.rs
+++ b/tests/integration_mock/notifications.rs
@@ -65,4 +65,6 @@ async fn server_push_reaches_receive_message() {
     })
     .await
     .expect("notification flow finishes within 5s");
+
+    server.finish().await;
 }

--- a/tests/integration_mock/reconnect.rs
+++ b/tests/integration_mock/reconnect.rs
@@ -1,0 +1,129 @@
+//! Manual reconnect flow.
+//!
+//! The library does not ship an automatic reconnect loop yet; reconnect
+//! is caller-driven via `disconnect()` + `connect()` (or just a fresh
+//! `connect()`, which tears down the old dispatcher). This test proves
+//! the caller-driven path works end-to-end against the mock:
+//!
+//! 1. Connect, subscribe, receive ACK.
+//! 2. Mock closes the socket.
+//! 3. Client calls `connect()` again on the same URL; the mock listener
+//!    accepts a second handshake.
+//! 4. Client replays the subscription (using
+//!    [`SubscriptionManager::get_all_channels`]) and the mock echoes
+//!    the confirmed channel list.
+//! 5. Assert that the mock observed two subscribe frames and the
+//!    client's subscription manager still reports the channel active.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+
+use super::helpers::client::mock_client;
+use super::helpers::frames::subscribe_success;
+use super::helpers::mock_server::spawn_mock_server_twice;
+
+const CHANNEL: &str = "ticker.BTC-PERPETUAL.raw";
+
+#[tokio::test]
+async fn manual_reconnect_replays_subscription() {
+    let observed_methods: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let observed_first = Arc::clone(&observed_methods);
+    let observed_second = Arc::clone(&observed_methods);
+
+    let server = spawn_mock_server_twice(
+        |mut sink, mut stream| async move {
+            // First connection: handle the subscribe, then close the
+            // socket to simulate a server-initiated disconnect.
+            if let Some(Ok(Message::Text(text))) = stream.next().await {
+                let request: Value = serde_json::from_str(&text).expect("subscribe request parses");
+                let id = request.get("id").cloned().unwrap_or(Value::Null);
+                let method = request["method"].as_str().unwrap_or("").to_owned();
+                observed_first.lock().await.push(method);
+                let _ = sink
+                    .send(Message::Text(subscribe_success(&id, &[CHANNEL]).into()))
+                    .await;
+            }
+            let _ = sink.close().await;
+        },
+        |mut sink, mut stream| async move {
+            // Second connection: the client replays the subscription.
+            if let Some(Ok(Message::Text(text))) = stream.next().await {
+                let request: Value = serde_json::from_str(&text).expect("subscribe replay parses");
+                let id = request.get("id").cloned().unwrap_or(Value::Null);
+                let method = request["method"].as_str().unwrap_or("").to_owned();
+                observed_second.lock().await.push(method);
+                let _ = sink
+                    .send(Message::Text(subscribe_success(&id, &[CHANNEL]).into()))
+                    .await;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        },
+    )
+    .await;
+
+    let client = mock_client(&server);
+
+    timeout(Duration::from_secs(5), async {
+        // Phase 1: initial connect + subscribe.
+        client.connect().await.expect("initial connect");
+        client
+            .subscribe(vec![CHANNEL.to_string()])
+            .await
+            .expect("initial subscribe");
+
+        // Phase 2: manual reconnect. `connect()` tears down the old
+        // (EOF) dispatcher and installs a fresh one against the
+        // listener's second accept.
+        client.connect().await.expect("reconnect");
+
+        // Phase 3: replay every known channel through the new
+        // dispatcher. `get_all_channels` includes previously subscribed
+        // channels whose entries are preserved across reconnects.
+        let channels = client
+            .subscription_manager()
+            .lock()
+            .await
+            .get_all_channels();
+        assert!(
+            channels.iter().any(|c| c == CHANNEL),
+            "manager must remember the channel across reconnect, got {:?}",
+            channels
+        );
+        client.subscribe(channels).await.expect("replay subscribe");
+
+        let active = client
+            .subscription_manager()
+            .lock()
+            .await
+            .get_active_channels();
+        assert!(
+            active.iter().any(|c| c == CHANNEL),
+            "{} must be active after reconnect, got {:?}",
+            CHANNEL,
+            active
+        );
+
+        client.disconnect().await.expect("disconnect");
+    })
+    .await
+    .expect("reconnect flow finishes within 5s");
+
+    let methods = observed_methods.lock().await;
+    assert_eq!(
+        methods.len(),
+        2,
+        "mock must have observed two subscribe frames, got {:?}",
+        methods
+    );
+    assert!(
+        methods.iter().all(|m| m == "public/subscribe"),
+        "both observed frames must be public/subscribe, got {:?}",
+        methods
+    );
+}

--- a/tests/integration_mock/reconnect.rs
+++ b/tests/integration_mock/reconnect.rs
@@ -126,4 +126,9 @@ async fn manual_reconnect_replays_subscription() {
         "both observed frames must be public/subscribe, got {:?}",
         methods
     );
+    // Release the guard before awaiting the server task to avoid holding
+    // the mutex across the await point.
+    drop(methods);
+
+    server.finish().await;
 }

--- a/tests/integration_mock/subscriptions.rs
+++ b/tests/integration_mock/subscriptions.rs
@@ -20,24 +20,49 @@ const CHANNEL: &str = "ticker.BTC-PERPETUAL.raw";
 #[tokio::test]
 async fn subscribe_and_unsubscribe_update_manager() {
     let server = spawn_mock_server(|mut sink, mut stream| async move {
-        // Accept two requests: subscribe first, then unsubscribe. Both
-        // echo the single channel back as a success result.
-        for _ in 0..2 {
-            let text = match stream.next().await {
-                Some(Ok(Message::Text(t))) => t,
-                _ => return,
-            };
-            let request: Value = serde_json::from_str(&text).expect("request parses as JSON");
-            let id = request.get("id").cloned().unwrap_or(Value::Null);
-            let method = request["method"].as_str().unwrap_or("");
-            let reply = if method.ends_with("/subscribe") {
-                subscribe_success(&id, &[CHANNEL])
-            } else {
-                unsubscribe_success(&id, &[CHANNEL])
-            };
-            let _ = sink.send(Message::Text(reply.into())).await;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Accept the subscribe first, assert its method is literally
+        // `public/subscribe`, then echo the channel list.
+        let subscribe_text = match stream.next().await {
+            Some(Ok(Message::Text(t))) => t,
+            _ => return,
+        };
+        let subscribe_request: Value =
+            serde_json::from_str(&subscribe_text).expect("subscribe request parses as JSON");
+        let subscribe_id = subscribe_request.get("id").cloned().unwrap_or(Value::Null);
+        assert_eq!(
+            subscribe_request["method"].as_str().unwrap_or(""),
+            "public/subscribe",
+            "first request must be public/subscribe, got {}",
+            subscribe_request["method"]
+        );
+        let _ = sink
+            .send(Message::Text(
+                subscribe_success(&subscribe_id, &[CHANNEL]).into(),
+            ))
+            .await;
+
+        // Then the unsubscribe, same assertion pattern.
+        let unsubscribe_text = match stream.next().await {
+            Some(Ok(Message::Text(t))) => t,
+            _ => return,
+        };
+        let unsubscribe_request: Value =
+            serde_json::from_str(&unsubscribe_text).expect("unsubscribe request parses as JSON");
+        let unsubscribe_id = unsubscribe_request
+            .get("id")
+            .cloned()
+            .unwrap_or(Value::Null);
+        assert_eq!(
+            unsubscribe_request["method"].as_str().unwrap_or(""),
+            "public/unsubscribe",
+            "second request must be public/unsubscribe, got {}",
+            unsubscribe_request["method"]
+        );
+        let _ = sink
+            .send(Message::Text(
+                unsubscribe_success(&unsubscribe_id, &[CHANNEL]).into(),
+            ))
+            .await;
     })
     .await;
 

--- a/tests/integration_mock/subscriptions.rs
+++ b/tests/integration_mock/subscriptions.rs
@@ -84,4 +84,6 @@ async fn subscribe_and_unsubscribe_update_manager() {
     })
     .await
     .expect("subscribe flow finishes within 5s");
+
+    server.finish().await;
 }

--- a/tests/integration_mock/subscriptions.rs
+++ b/tests/integration_mock/subscriptions.rs
@@ -1,0 +1,87 @@
+//! Subscribe / unsubscribe round-trip against the mock server.
+//!
+//! Verifies that [`DeribitWebSocketClient::subscribe`] reconciles the
+//! local [`SubscriptionManager`] from the server-confirmed channel list
+//! and that [`DeribitWebSocketClient::unsubscribe`] removes them again.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+
+use super::helpers::client::mock_client;
+use super::helpers::frames::{subscribe_success, unsubscribe_success};
+use super::helpers::mock_server::spawn_mock_server;
+
+const CHANNEL: &str = "ticker.BTC-PERPETUAL.raw";
+
+#[tokio::test]
+async fn subscribe_and_unsubscribe_update_manager() {
+    let server = spawn_mock_server(|mut sink, mut stream| async move {
+        // Accept two requests: subscribe first, then unsubscribe. Both
+        // echo the single channel back as a success result.
+        for _ in 0..2 {
+            let text = match stream.next().await {
+                Some(Ok(Message::Text(t))) => t,
+                _ => return,
+            };
+            let request: Value = serde_json::from_str(&text).expect("request parses as JSON");
+            let id = request.get("id").cloned().unwrap_or(Value::Null);
+            let method = request["method"].as_str().unwrap_or("");
+            let reply = if method.ends_with("/subscribe") {
+                subscribe_success(&id, &[CHANNEL])
+            } else {
+                unsubscribe_success(&id, &[CHANNEL])
+            };
+            let _ = sink.send(Message::Text(reply.into())).await;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    })
+    .await;
+
+    let client = mock_client(&server);
+
+    timeout(Duration::from_secs(5), async {
+        client.connect().await.expect("connect");
+
+        client
+            .subscribe(vec![CHANNEL.to_string()])
+            .await
+            .expect("subscribe");
+
+        let active_after_sub = client
+            .subscription_manager()
+            .lock()
+            .await
+            .get_active_channels();
+        assert!(
+            active_after_sub.iter().any(|c| c == CHANNEL),
+            "{} must be active after subscribe, got {:?}",
+            CHANNEL,
+            active_after_sub
+        );
+
+        client
+            .unsubscribe(vec![CHANNEL.to_string()])
+            .await
+            .expect("unsubscribe");
+
+        let active_after_unsub = client
+            .subscription_manager()
+            .lock()
+            .await
+            .get_active_channels();
+        assert!(
+            !active_after_unsub.iter().any(|c| c == CHANNEL),
+            "{} must be gone after unsubscribe, got {:?}",
+            CHANNEL,
+            active_after_unsub
+        );
+
+        client.disconnect().await.expect("disconnect");
+    })
+    .await
+    .expect("subscribe flow finishes within 5s");
+}

--- a/tests/integration_mock/timeout.rs
+++ b/tests/integration_mock/timeout.rs
@@ -27,9 +27,14 @@ const TIMEOUT_OBSERVATION_BOUND: Duration = Duration::from_millis(750);
 #[tokio::test]
 async fn request_timeout_fires_on_silent_server() {
     let server = spawn_mock_server(|_sink, mut stream| async move {
-        // Read the request and deliberately never reply.
+        // Read the request and deliberately never reply. Then drain the
+        // stream until the client closes the socket so the server-side
+        // socket stays alive long enough for the client's request
+        // timeout to fire (rather than racing against a fixed sleep),
+        // and the scenario — and therefore `server.finish()` — returns
+        // promptly once the client is done.
         let _ = stream.next().await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        while stream.next().await.is_some() {}
     })
     .await;
 
@@ -60,4 +65,6 @@ async fn request_timeout_fires_on_silent_server() {
     })
     .await
     .expect("timeout flow finishes within 5s");
+
+    server.finish().await;
 }

--- a/tests/integration_mock/timeout.rs
+++ b/tests/integration_mock/timeout.rs
@@ -1,0 +1,63 @@
+//! Per-request timeout enforcement.
+//!
+//! When the server accepts a request but never replies, the client
+//! must surface [`WebSocketError::Timeout`] within roughly the
+//! configured `request_timeout`, not hang forever.
+
+use std::time::Duration;
+
+use deribit_websocket::prelude::*;
+use futures_util::StreamExt;
+use tokio::time::timeout;
+
+use super::helpers::client::mock_config;
+use super::helpers::mock_server::spawn_mock_server;
+
+/// Configured `request_timeout` for this test. Short enough that CI
+/// wall-clock noise is dwarfed by the deadline, long enough that
+/// scheduling jitter on a slow runner still gets the timer fired
+/// before the scenario's own sleep expires.
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(150);
+
+/// Upper bound on how long the client may take to surface the timeout.
+/// 5x headroom over the deadline, matching the convention used in the
+/// dispatcher unit tests.
+const TIMEOUT_OBSERVATION_BOUND: Duration = Duration::from_millis(750);
+
+#[tokio::test]
+async fn request_timeout_fires_on_silent_server() {
+    let server = spawn_mock_server(|_sink, mut stream| async move {
+        // Read the request and deliberately never reply.
+        let _ = stream.next().await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    })
+    .await;
+
+    let config = mock_config(&server).with_request_timeout(REQUEST_TIMEOUT);
+    let client = DeribitWebSocketClient::new(&config).expect("client construction");
+
+    timeout(Duration::from_secs(5), async {
+        client.connect().await.expect("connect");
+
+        let start = std::time::Instant::now();
+        let result = client.get_time().await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(result, Err(WebSocketError::Timeout(_))),
+            "expected Timeout, got {:?}",
+            result
+        );
+        assert!(
+            elapsed < TIMEOUT_OBSERVATION_BOUND,
+            "timeout must fire within {:?} of the {:?} deadline, took {:?}",
+            TIMEOUT_OBSERVATION_BOUND,
+            REQUEST_TIMEOUT,
+            elapsed
+        );
+
+        client.disconnect().await.expect("disconnect");
+    })
+    .await
+    .expect("timeout flow finishes within 5s");
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,6 +5,11 @@
 // that are enforced on the library crate here.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+// Disambiguate from the sibling `tests/integration.rs` test binary
+// (issue #53 mock-server suite). Without this attribute, Rust cannot
+// decide whether `mod integration;` refers to `tests/integration.rs`
+// or `tests/integration/mod.rs` and rejects the build with E0761.
+#[path = "integration/mod.rs"]
 mod integration;
 mod unit;
 


### PR DESCRIPTION
## Summary

Add a self-contained mock-server integration test suite that exercises the public `DeribitWebSocketClient` API end-to-end without any Deribit credentials or network access. Closes the coverage gap called out in #53: auth, subscribe/unsubscribe, notification delivery, reconnect, request/response id matching, and timeout handling now each have at least one test that runs in CI on every push.

## Changes

- New `cargo test --test integration` binary at `tests/integration.rs` (matches issue #53's literal acceptance criterion).
- New `tests/integration_mock/` tree with six test modules — one per flow — plus shared helpers under `tests/integration_mock/helpers/`:
  - `mock_server.rs` — `spawn_mock_server` (single accept) and `spawn_mock_server_twice` (two sequential accepts, used by the reconnect test). Returns a `MockServer` handle that aborts its background task on `Drop` so tests cannot leak server tasks.
  - `client.rs` — `mock_config` / `mock_client` build a `WebSocketConfig` pointing at the mock's ephemeral port with tight deterministic timeouts and logging disabled.
  - `frames.rs` — JSON-RPC payload constructors: `auth_success`, `subscribe_success`, `unsubscribe_success`, `ticker_notification`, `u64_result`.
- Tests:
  - `auth.rs` — `public/auth` request shape + `AuthResponse` parsing.
  - `subscriptions.rs` — subscribe reconciles the `SubscriptionManager`, unsubscribe removes the entry.
  - `notifications.rs` — server push arrives through `receive_message` with `method == "subscription"` and the expected channel.
  - `reconnect.rs` — manual caller-driven reconnect: first mock connection closes, client calls `connect()` again, subscription replayed through the second accept; asserts the mock observed two `public/subscribe` frames.
  - `id_matching.rs` — three concurrent `get_time()` calls; mock replies in reverse id order; each caller's future resolves to the value keyed by *its own* id.
  - `timeout.rs` — silent server; `WebSocketError::Timeout` surfaces within the configured `request_timeout` (5× headroom vs the deadline).
- `tests/lib.rs` gains a single `#[path = "integration/mod.rs"]` attribute to disambiguate the pre-existing `mod integration;` declaration from the new `tests/integration.rs` binary. No behavioural change for the existing live-server suite.

## Technical Decisions

- **Separate `tests/integration_mock/` tree, not inside `tests/integration/`.** Keeps the existing live-server tests (feature-gated on `integration-tests`, credential-driven) completely untouched and makes the mock/live split visible at file-path level.
- **Dedicated `tests/integration.rs` binary.** Produces exactly `cargo test --test integration` as the issue's acceptance requires, without having to rename or repurpose `tests/lib.rs`.
- **No source-crate changes, no new dependencies, no new features.** `tokio-tungstenite`, `tokio`, `futures-util`, `serde_json`, and `url` are already deps of the library and therefore available to the test binary.
- **Reconnect scope: caller-driven.** The library does not currently implement an auto-reconnect loop (config + state exist, loop does not). The test exercises the supported flow — `connect` → `subscribe` → server drops → `connect` again → replay from the preserved `SubscriptionManager` state — and proves that end-to-end path is correct. An auto-reconnect loop, when added, can extend this test without replacing it.
- **Timing bounds use 5× headroom** (`timeout` test's deadline is 150 ms, observation bound 750 ms) matching the existing dispatcher-level unit tests. Ten back-to-back local runs finished in 0.15–0.16 s each with zero failures.

## Testing

- [x] Unit tests added/updated — six new integration tests, no changes to library or existing unit tests.
- [x] Integration tests added/updated — this PR *is* the integration test suite.
- [ ] Benchmark tests added/updated — N/A.
- [x] Manual testing performed — `cargo test --test integration` green (6 / 6), `cargo test` green (431 / 431, +6 vs main), `cargo build --release` zero warnings, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo clippy --lib --tests --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` clean, `cargo fmt --check` clean. Ten sequential runs of `cargo test --test integration` all pass — no flakiness observed.

## Checklist

- [x] All public items have `///` documentation — all helpers are `pub(crate)` and carry `///` docs.
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`.
- [x] `cargo fmt --all --check` passes.
- [x] No `.unwrap()`, `.expect()`, or panics in library code — test code uses them for assertion clarity per the existing `#![allow(clippy::unwrap_used, clippy::expect_used)]` convention already applied to `tests/lib.rs`.
- [x] WebSocket connection lifecycle handled — every test connects and disconnects cleanly; `MockServer::drop` aborts the server task.
- [x] Minimal dependencies — no unnecessary crates added. Zero new dependencies.

Closes #53
