### PR TITLE
#54 #56 #57: polish pass — CI examples, rustdoc audit, config clone reduction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,14 @@ jobs:
           sudo apt-get update && sudo apt-get install -y \
             make libfontconfig1-dev pkg-config build-essential libssl-dev
 
-      - name: Build (${{ matrix.tls }})
-        run: cargo build --no-default-features --features ${{ matrix.tls }}
+      # `--all-targets` = lib + bins + tests + examples + benches. This
+      # gives us CI coverage of every `examples/*.rs` under every TLS
+      # backend for free (per issue #54) instead of a dedicated
+      # single-backend "compile examples" step — if an example ever
+      # stops compiling, one of the six matrix cells fails.
+      - name: Build --all-targets (${{ matrix.tls }})
+        run: cargo build --all-targets --no-default-features --features ${{ matrix.tls
+          }}
 
   # Negative-case build: asserts the `compile_error!` mutex in
   # `src/tls.rs` rejects two TLS backends simultaneously. If the build
@@ -78,3 +84,27 @@ jobs:
             exit 1
           fi
           echo "mutex correctly rejected the double-backend build"
+
+  # Build rustdoc with warnings-as-errors (per issue #56). Catches dead
+  # intra-doc links, missing crate-level docs, and private-item leaks
+  # before they land on docs.rs. `--features integration-tests` is used
+  # instead of `--all-features` because the latter activates all three
+  # mutually-exclusive TLS backends at once and trips the compile_error!
+  # mutex — same reasoning as `make lint`.
+  rustdoc:
+    runs-on: ubuntu-latest
+    name: rustdoc (-D warnings)
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            make libfontconfig1-dev pkg-config build-essential
+
+      - name: cargo doc --features integration-tests
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --features integration-tests

--- a/src/client.rs
+++ b/src/client.rs
@@ -79,14 +79,22 @@ pub struct DeribitWebSocketClient {
 
 impl DeribitWebSocketClient {
     /// Create a new WebSocket client
+    ///
+    /// The caller's `&WebSocketConfig` is deep-copied once into an
+    /// `Arc<WebSocketConfig>` which is then shared with the inner
+    /// [`WebSocketSession`] via `Arc::clone` — no second struct clone,
+    /// no double allocation.
     pub fn new(config: &WebSocketConfig) -> Result<Self, WebSocketError> {
         let subscription_manager = Arc::new(Mutex::new(SubscriptionManager::new()));
+        // One unavoidable deep copy: we start from `&WebSocketConfig`
+        // and need an owned value to place inside the `Arc`. Every
+        // subsequent hand-off is a cheap `Arc::clone`.
+        let config = Arc::new(config.clone());
         let session = Arc::new(WebSocketSession::new(
-            config.clone(),
+            Arc::clone(&config),
             Arc::clone(&subscription_manager),
         ));
 
-        let config = Arc::new(config.clone());
         Ok(Self {
             config,
             dispatcher: Arc::new(Mutex::new(None)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,17 +29,17 @@ pub struct WebSocketConfig {
     pub client_id: Option<String>,
     /// Client secret for authentication
     pub client_secret: Option<String>,
-    /// Per-request timeout for [`DeribitWebSocketClient::send_request`].
+    /// Per-request timeout for [`crate::client::DeribitWebSocketClient::send_request`].
     ///
     /// Every call that awaits a matching JSON-RPC response is bounded by
     /// this duration. If the response does not arrive in time, the call
-    /// returns [`WebSocketError::Timeout`].
+    /// returns [`crate::error::WebSocketError::Timeout`].
     pub request_timeout: Duration,
     /// Notification channel capacity (frames buffered for the consumer).
     ///
     /// Depth of the bounded `tokio::sync::mpsc` that carries server-pushed
     /// notifications (and any unmatched frames) from the dispatcher task
-    /// to [`DeribitWebSocketClient::receive_message`] /
+    /// to [`crate::client::DeribitWebSocketClient::receive_message`] /
     /// `start_message_processing_loop`.
     ///
     /// # Backpressure — Strategy A (await-send)
@@ -68,13 +68,13 @@ pub struct WebSocketConfig {
     /// # Backpressure — Strategy A (await-send)
     ///
     /// When the channel is full, callers of
-    /// [`DeribitWebSocketClient::send_request`] /
-    /// [`DeribitWebSocketClient::disconnect`] block on `send().await`
+    /// [`crate::client::DeribitWebSocketClient::send_request`] /
+    /// [`crate::client::DeribitWebSocketClient::disconnect`] block on `send().await`
     /// until the dispatcher drains a slot. Blocking here means the
     /// application is issuing requests faster than the dispatcher can
     /// write them to the socket; the `request_timeout` bound on
     /// `send_request` still applies, so the caller sees a
-    /// [`WebSocketError::Timeout`] if the deadline elapses while
+    /// [`crate::error::WebSocketError::Timeout`] if the deadline elapses while
     /// waiting on the command channel.
     pub dispatcher_command_capacity: usize,
 }
@@ -102,7 +102,7 @@ impl WebSocketConfig {
     /// Construct a configuration from environment variables, propagating
     /// parse errors for any user-supplied URL.
     ///
-    /// Loads `.env` once via [`Self::load_env`], reads `DERIBIT_WS_URL`
+    /// Loads `.env` once via `Self::load_env`, reads `DERIBIT_WS_URL`
     /// (falling back to [`constants::PRODUCTION_WS_URL`] when unset), and
     /// parses it. All other fields follow the same env-or-default strategy as
     /// [`Default`] but never fail.
@@ -127,7 +127,7 @@ impl WebSocketConfig {
     ///
     /// Non-URL fields are populated from environment variables using the
     /// same rules as [`Default`]; only the URL is overridden. `.env` is
-    /// loaded once via [`Self::load_env`] before any env var is read.
+    /// loaded once via `Self::load_env` before any env var is read.
     ///
     /// # Errors
     ///
@@ -152,7 +152,7 @@ impl WebSocketConfig {
     /// Private helper: populate every field except `ws_url` from environment
     /// variables (with sensible defaults) and combine them with the given URL.
     ///
-    /// The caller is responsible for calling [`Self::load_env`] beforehand so
+    /// The caller is responsible for calling `Self::load_env` beforehand so
     /// that `.env` overrides are visible to `std::env::var`. Every public
     /// constructor satisfies this invariant.
     fn from_parts(ws_url: Url) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,12 @@
 
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
+// Catch dead rustdoc links and missing crate-level docs in CI via
+// `RUSTDOCFLAGS="-D warnings" cargo doc`. `missing_crate_level_docs`
+// is technically redundant with the substantial `//!` header above
+// but it guards against the header ever being deleted in a refactor.
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(rustdoc::missing_crate_level_docs)]
 // Regression guard against future `std::sync::Mutex` use across `.await`.
 // Tokio's mutex (which this crate uses) is intentionally allowed.
 #![warn(clippy::await_holding_lock)]

--- a/src/message/builder.rs
+++ b/src/message/builder.rs
@@ -1,9 +1,31 @@
-//! Message builder utilities for WebSocket client
+//! Aggregate message builder and parser for JSON-RPC traffic.
+//!
+//! Combines the three stateless helpers in [`crate::message`] into a
+//! single facade: [`RequestBuilder`] for *outbound* JSON-RPC requests,
+//! [`ResponseHandler`] for *inbound* replies, and [`NotificationHandler`]
+//! for server-initiated pushes. Typical usage is to hold one
+//! [`MessageBuilder`] per connection and feed every frame read off the
+//! wire to [`MessageBuilder::parse_message`], dispatching on the
+//! returned [`MessageType`].
 
 use crate::message::{NotificationHandler, RequestBuilder, ResponseHandler};
 use crate::model::ws_types::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 
-/// Main message builder for WebSocket operations
+/// Aggregate JSON-RPC message builder/parser.
+///
+/// Holds the three sub-components needed to drive a JSON-RPC session:
+///
+/// - [`RequestBuilder`] — produces outbound requests and assigns
+///   monotonically-increasing ids; held mutably because it mutates
+///   that id counter on every call.
+/// - [`ResponseHandler`] — parses inbound replies keyed by id; fully
+///   stateless, so a shared reference is enough.
+/// - [`NotificationHandler`] — parses server-initiated pushes
+///   (subscription events, heartbeats); also stateless.
+///
+/// One instance per WebSocket connection is the intended lifetime: the
+/// id counter must not be shared across connections, and the handlers
+/// hold no connection-specific state.
 #[derive(Debug)]
 pub struct MessageBuilder {
     request_builder: RequestBuilder,
@@ -18,7 +40,9 @@ impl Default for MessageBuilder {
 }
 
 impl MessageBuilder {
-    /// Create a new message builder
+    /// Create a new aggregate message builder with a fresh id counter
+    /// and stateless response/notification parsers.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             request_builder: RequestBuilder::new(),
@@ -27,22 +51,49 @@ impl MessageBuilder {
         }
     }
 
-    /// Get mutable reference to request builder
+    /// Borrow the request builder mutably.
+    ///
+    /// Mutability is required because every outbound request advances
+    /// the builder's id counter. Prefer calling this from a single
+    /// task: the `MessageBuilder` itself is not `Sync`-protected.
     pub fn request_builder(&mut self) -> &mut RequestBuilder {
         &mut self.request_builder
     }
 
-    /// Get reference to response handler
+    /// Borrow the response handler.
+    ///
+    /// Returned as an immutable reference because the handler is a pure
+    /// JSON-to-DTO parser with no internal state.
+    #[must_use]
     pub fn response_handler(&self) -> &ResponseHandler {
         &self.response_handler
     }
 
-    /// Get reference to notification handler
+    /// Borrow the notification handler.
+    ///
+    /// Returned as an immutable reference because the handler is a pure
+    /// JSON-to-DTO parser with no internal state.
+    #[must_use]
     pub fn notification_handler(&self) -> &NotificationHandler {
         &self.notification_handler
     }
 
-    /// Parse incoming message and determine type
+    /// Classify and parse a raw JSON-RPC frame.
+    ///
+    /// Attempts the response path first (JSON-RPC 2.0 responses always
+    /// carry an `id`), then the notification path (notifications never
+    /// have `id`). Outbound-only [`JsonRpcRequest`]s — the third
+    /// [`MessageType`] variant — are produced by [`RequestBuilder`],
+    /// not by this parser, so receiving a "request-shaped" frame from
+    /// the server is treated as invalid data.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`serde_json::Error`] of kind [`std::io::ErrorKind::InvalidData`]
+    /// when `data` parses as neither a response nor a notification —
+    /// typically because it is malformed JSON, lacks both an `id` and a
+    /// `method`, or looks like an outbound request rather than an
+    /// inbound frame.
     pub fn parse_message(&self, data: &str) -> Result<MessageType, serde_json::Error> {
         // Try to parse as response first (has 'id' field)
         if let Ok(response) = self.response_handler.parse_response(data) {
@@ -62,13 +113,24 @@ impl MessageBuilder {
     }
 }
 
-/// Message type enumeration
+/// Classification of a JSON-RPC 2.0 frame.
+///
+/// Emitted by [`MessageBuilder::parse_message`] to let callers dispatch
+/// on the three fundamental flavours of traffic in a JSON-RPC session.
 #[derive(Debug, Clone)]
 pub enum MessageType {
-    /// JSON-RPC request message
+    /// Outbound request frame — `method`, `params`, and a numeric `id`.
+    ///
+    /// Never produced by [`MessageBuilder::parse_message`]; reserved
+    /// for code paths that construct requests via [`RequestBuilder`]
+    /// and want to round-trip them through the same enum.
     Request(JsonRpcRequest),
-    /// JSON-RPC response message
+    /// Inbound reply frame correlated with a previously-sent request
+    /// via a shared numeric `id`. Carries either a `result` or an
+    /// `error` payload (never both).
     Response(JsonRpcResponse),
-    /// JSON-RPC notification message
+    /// Server-initiated push frame. Has a `method` and `params` like a
+    /// request but no `id`, so it expects no reply. Examples:
+    /// subscription updates, heartbeats.
     Notification(JsonRpcNotification),
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,56 @@
-//! Prelude module for commonly used types and traits
+//! Curated glob-importable re-exports for common use cases.
 //!
-//! This module re-exports the most commonly used types from the deribit-websocket crate,
-//! making it easy to import everything needed with a single `use` statement.
+//! ```rust,no_run
+//! use deribit_websocket::prelude::*;
+//! ```
+//!
+//! Type names below are rendered as plain code rather than as rustdoc
+//! intra-doc links because this module doc is emitted before the
+//! re-exports it describes, so the linker would not resolve them.
+//!
+//! # What you get
+//!
+//! - **Client + config** — `DeribitWebSocketClient`, `WebSocketConfig`,
+//!   and the message-handler types (`MessageHandler`,
+//!   `MessageHandlerBuilder`, `MessageCallback`, `ErrorCallback`)
+//!   needed to drive a live connection.
+//! - **Session / connection** — `WebSocketSession` and
+//!   `WebSocketConnection` for consumers that want to hold the
+//!   underlying session directly.
+//! - **Error type** — `WebSocketError`. All fallible operations in this
+//!   crate return `Result<T, WebSocketError>`.
+//! - **DTOs commonly seen on the wire** — JSON-RPC envelopes
+//!   (`JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcNotification`,
+//!   `JsonRpcError`, `JsonRpcResult`), trading structures
+//!   (`OrderRequest`, `OrderResponse`, `OrderInfo`, `TradeExecution`,
+//!   `Position`, etc.), mass-quote structures (`Quote`,
+//!   `MassQuoteRequest`, `MassQuoteResult`, `MmpGroupConfig`, …), and
+//!   account/subscription helpers.
+//! - **Message helpers** — `MessageBuilder`, `RequestBuilder`,
+//!   `ResponseHandler`, `NotificationHandler`.
+//! - **Constants** — everything from [`crate::constants`], including
+//!   default URLs and channel name prefixes.
+//! - **`setup_logger`** — quick `tracing` initialisation driven by
+//!   `DERIBIT_LOG_LEVEL`.
+//! - **A small slice of external types** — [`serde_json::Value`],
+//!   [`serde_json::json`], and
+//!   [`tokio_tungstenite::tungstenite::Message`] (re-exported as
+//!   `TungsteniteMessage`) because they appear in almost every
+//!   callback signature.
+//!
+//! # What you do *not* get
+//!
+//! The prelude is intentionally narrow. The following are **not**
+//! re-exported and should be imported by path when needed:
+//!
+//! - Less-common model variants — browse [`crate::model`] for the full
+//!   list (instrument metadata, chart candles, etc.).
+//! - Low-level dispatcher / connection internals — see
+//!   [`crate::connection`].
+//! - TLS backend helpers — see [`crate::tls`] and the crate-level
+//!   [`crate::install_default_crypto_provider`].
+//! - The `error` module sub-types beyond `WebSocketError` — see
+//!   [`crate::error`] for envelope builders and helpers.
 
 // Callback system
 pub use crate::callback::{ErrorCallback, MessageCallback, MessageHandler, MessageHandlerBuilder};

--- a/src/session/ws_session.rs
+++ b/src/session/ws_session.rs
@@ -18,10 +18,10 @@ impl WebSocketSession {
     /// Create a new WebSocket session.
     ///
     /// Takes the configuration as an `Arc<WebSocketConfig>` so it can be
-    /// shared with [`DeribitWebSocketClient`](crate::DeribitWebSocketClient)
-    /// (which stores the same `Arc`) without deep-copying the config
-    /// struct. Callers that start from an owned `WebSocketConfig` should
-    /// wrap it once via `Arc::new(config)` before calling.
+    /// shared with [`crate::client::DeribitWebSocketClient`] (which
+    /// stores the same `Arc`) without deep-copying the config struct.
+    /// Callers that start from an owned `WebSocketConfig` should wrap
+    /// it once via `Arc::new(config)` before calling.
     pub fn new(
         config: Arc<WebSocketConfig>,
         subscription_manager: Arc<Mutex<SubscriptionManager>>,

--- a/src/session/ws_session.rs
+++ b/src/session/ws_session.rs
@@ -17,17 +17,20 @@ pub struct WebSocketSession {
 impl WebSocketSession {
     /// Create a new WebSocket session.
     ///
-    /// Takes the configuration as an `Arc<WebSocketConfig>` so it can be
-    /// shared with [`crate::client::DeribitWebSocketClient`] (which
-    /// stores the same `Arc`) without deep-copying the config struct.
-    /// Callers that start from an owned `WebSocketConfig` should wrap
-    /// it once via `Arc::new(config)` before calling.
+    /// Accepts anything convertible into `Arc<WebSocketConfig>`, which
+    /// via Rust's blanket `impl<T> From<T> for Arc<T>` covers both an
+    /// owned `WebSocketConfig` (wrapped once here) and an existing
+    /// `Arc<WebSocketConfig>` shared with
+    /// [`crate::client::DeribitWebSocketClient`] (zero extra copies).
+    /// This keeps the constructor backward-compatible with pre-existing
+    /// owned-value call sites while also giving the client a zero-copy
+    /// path for its shared configuration.
     pub fn new(
-        config: Arc<WebSocketConfig>,
+        config: impl Into<Arc<WebSocketConfig>>,
         subscription_manager: Arc<Mutex<SubscriptionManager>>,
     ) -> Self {
         Self {
-            config,
+            config: config.into(),
             state: Arc::new(Mutex::new(ConnectionState::Disconnected)),
             subscription_manager,
         }

--- a/src/session/ws_session.rs
+++ b/src/session/ws_session.rs
@@ -15,13 +15,19 @@ pub struct WebSocketSession {
 }
 
 impl WebSocketSession {
-    /// Create a new WebSocket session
+    /// Create a new WebSocket session.
+    ///
+    /// Takes the configuration as an `Arc<WebSocketConfig>` so it can be
+    /// shared with [`DeribitWebSocketClient`](crate::DeribitWebSocketClient)
+    /// (which stores the same `Arc`) without deep-copying the config
+    /// struct. Callers that start from an owned `WebSocketConfig` should
+    /// wrap it once via `Arc::new(config)` before calling.
     pub fn new(
-        config: WebSocketConfig,
+        config: Arc<WebSocketConfig>,
         subscription_manager: Arc<Mutex<SubscriptionManager>>,
     ) -> Self {
         Self {
-            config: Arc::new(config),
+            config,
             state: Arc::new(Mutex::new(ConnectionState::Disconnected)),
             subscription_manager,
         }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -83,8 +83,8 @@ pub enum CryptoProviderError {
 ///   OS TLS stack does not require any process-level initialization.
 ///
 /// Call this exactly once at application startup, before any call to
-/// [`crate::DeribitWebSocketClient::connect`]. Subsequent calls return
-/// [`CryptoProviderError::AlreadyInstalled`] rather than panic, which
+/// [`crate::client::DeribitWebSocketClient::connect`]. Subsequent calls
+/// return [`CryptoProviderError::AlreadyInstalled`] rather than panic, which
 /// lets callers be robust against multiple entry points (tests, libs,
 /// `main`) all trying to initialize the provider.
 ///

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -1,6 +1,8 @@
-//! Logger setup utility for the deribit-websocket crate
+//! `tracing` subscriber setup, driven by `DERIBIT_LOG_LEVEL`.
 //!
-//! Provides a simple logger configuration based on environment variables.
+//! Installs a [`FmtSubscriber`] as the process-global default. The
+//! level comes from the `DERIBIT_LOG_LEVEL` environment variable read
+//! on the first call; subsequent calls are no-ops.
 
 use std::env;
 use std::sync::Once;
@@ -9,13 +11,23 @@ use tracing_subscriber::FmtSubscriber;
 
 static INIT: Once = Once::new();
 
-/// Sets up the logger for the application.
+/// Install the `tracing` subscriber used by every example and binary
+/// in the crate.
 ///
-/// The logger level is determined by the `DERIBIT_LOG_LEVEL` environment variable.
-/// If the variable is not set, it defaults to `INFO`.
+/// The level is read from the `DERIBIT_LOG_LEVEL` environment variable
+/// once, on the first call. Recognised values: `TRACE`, `DEBUG`,
+/// `INFO`, `WARN`, `ERROR`. Anything else (or an unset variable)
+/// defaults to `INFO`.
 ///
-/// This function is safe to call multiple times - it will only initialize
-/// the logger once.
+/// The subscriber is registered as the *process-global* default via
+/// [`tracing::subscriber::set_global_default`], which `tracing` allows
+/// only once per process. A [`Once`] guard makes subsequent calls to
+/// this function safe: they return immediately without touching the
+/// already-installed subscriber, so applications that wire logging
+/// from multiple entry points (tests, libs, `main`) do not race.
+///
+/// Changing `DERIBIT_LOG_LEVEL` after the first call has no effect —
+/// tracing does not support replacing the global default at runtime.
 ///
 /// # Example
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,23 @@
-//! Utility functions and helpers for the deribit-websocket crate
+//! Shared helpers for crate consumers.
 //!
-//! This module provides common utilities used throughout the crate.
+//! Currently a single entry point: [`crate::utils::setup_logger`],
+//! which installs a `tracing` subscriber driven by the
+//! `DERIBIT_LOG_LEVEL` environment variable. The helper is re-exported
+//! from [`crate::prelude`] so `use deribit_websocket::prelude::*;`
+//! makes it available without an explicit path.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use deribit_websocket::utils::setup_logger;
+//!
+//! // Default level is INFO; override via env var before the first call.
+//! unsafe {
+//!     std::env::set_var("DERIBIT_LOG_LEVEL", "DEBUG");
+//! }
+//! setup_logger();
+//! tracing::debug!("logger online");
+//! ```
 
 mod logger;
 

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -13,7 +13,7 @@ fn make_subscription_manager() -> Arc<Mutex<SubscriptionManager>> {
 #[test]
 fn test_websocket_session_creation() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Test that session can be created
     let debug_str = format!("{:?}", session);
@@ -23,7 +23,7 @@ fn test_websocket_session_creation() {
 #[test]
 fn test_websocket_session_with_production_config() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     let debug_str = format!("{:?}", session);
     assert!(debug_str.contains("WebSocketSession"));
@@ -35,7 +35,7 @@ fn test_websocket_session_with_custom_config() {
         .with_heartbeat_interval(std::time::Duration::from_secs(60))
         .with_max_reconnect_attempts(10);
 
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     let debug_str = format!("{:?}", session);
     assert!(debug_str.contains("WebSocketSession"));
@@ -44,10 +44,7 @@ fn test_websocket_session_with_custom_config() {
 #[test]
 fn test_websocket_session_arc_compatibility() {
     let config = WebSocketConfig::default();
-    let session = Arc::new(WebSocketSession::new(
-        Arc::new(config),
-        make_subscription_manager(),
-    ));
+    let session = Arc::new(WebSocketSession::new(config, make_subscription_manager()));
 
     // Test that session can be wrapped in Arc (for thread safety)
     let session_clone = session.clone();
@@ -62,7 +59,7 @@ fn test_websocket_session_arc_compatibility() {
 #[test]
 fn test_websocket_session_debug_format() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     let debug_output = format!("{:?}", session);
     assert!(debug_output.contains("WebSocketSession"));
@@ -73,7 +70,7 @@ fn test_websocket_session_config_access() {
     let config =
         WebSocketConfig::default().with_heartbeat_interval(std::time::Duration::from_secs(45));
 
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Test that config can be accessed
     let config_ref = session.config();
@@ -83,7 +80,7 @@ fn test_websocket_session_config_access() {
 #[test]
 fn test_websocket_session_subscription_manager() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Test that subscription manager can be accessed
     let manager = session.subscription_manager();
@@ -93,7 +90,7 @@ fn test_websocket_session_subscription_manager() {
 #[tokio::test]
 async fn test_websocket_session_state() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Initial state should be Disconnected
     let state = session.state().await;
@@ -105,7 +102,7 @@ async fn test_websocket_session_set_state() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Set state to Connected
     session.set_state(ConnectionState::Connected).await;
@@ -116,7 +113,7 @@ async fn test_websocket_session_set_state() {
 #[tokio::test]
 async fn test_websocket_session_is_connected_false() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // Initial state is Disconnected, so is_connected should be false
     assert!(!session.is_connected().await);
@@ -127,7 +124,7 @@ async fn test_websocket_session_is_connected_true() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     session.set_state(ConnectionState::Connected).await;
     assert!(session.is_connected().await);
@@ -136,7 +133,7 @@ async fn test_websocket_session_is_connected_true() {
 #[tokio::test]
 async fn test_websocket_session_is_authenticated_false() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     assert!(!session.is_authenticated().await);
 }
@@ -146,7 +143,7 @@ async fn test_websocket_session_is_authenticated_true() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     session.set_state(ConnectionState::Authenticated).await;
     assert!(session.is_authenticated().await);
@@ -155,7 +152,7 @@ async fn test_websocket_session_is_authenticated_true() {
 #[tokio::test]
 async fn test_websocket_session_mark_authenticated() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     session.mark_authenticated().await;
     assert!(session.is_authenticated().await);
@@ -166,7 +163,7 @@ async fn test_websocket_session_mark_disconnected() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // First connect and authenticate
     session.set_state(ConnectionState::Authenticated).await;
@@ -181,7 +178,7 @@ async fn test_websocket_session_mark_disconnected() {
 #[tokio::test]
 async fn test_websocket_session_reactivate_subscriptions() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
+    let session = WebSocketSession::new(config, make_subscription_manager());
 
     // This should not panic
     session.reactivate_subscriptions().await;

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -44,7 +44,10 @@ fn test_websocket_session_with_custom_config() {
 #[test]
 fn test_websocket_session_arc_compatibility() {
     let config = WebSocketConfig::default();
-    let session = Arc::new(WebSocketSession::new(Arc::new(config), make_subscription_manager()));
+    let session = Arc::new(WebSocketSession::new(
+        Arc::new(config),
+        make_subscription_manager(),
+    ));
 
     // Test that session can be wrapped in Arc (for thread safety)
     let session_clone = session.clone();

--- a/tests/unit/session.rs
+++ b/tests/unit/session.rs
@@ -13,7 +13,7 @@ fn make_subscription_manager() -> Arc<Mutex<SubscriptionManager>> {
 #[test]
 fn test_websocket_session_creation() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // Test that session can be created
     let debug_str = format!("{:?}", session);
@@ -23,7 +23,7 @@ fn test_websocket_session_creation() {
 #[test]
 fn test_websocket_session_with_production_config() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     let debug_str = format!("{:?}", session);
     assert!(debug_str.contains("WebSocketSession"));
@@ -35,7 +35,7 @@ fn test_websocket_session_with_custom_config() {
         .with_heartbeat_interval(std::time::Duration::from_secs(60))
         .with_max_reconnect_attempts(10);
 
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     let debug_str = format!("{:?}", session);
     assert!(debug_str.contains("WebSocketSession"));
@@ -44,7 +44,7 @@ fn test_websocket_session_with_custom_config() {
 #[test]
 fn test_websocket_session_arc_compatibility() {
     let config = WebSocketConfig::default();
-    let session = Arc::new(WebSocketSession::new(config, make_subscription_manager()));
+    let session = Arc::new(WebSocketSession::new(Arc::new(config), make_subscription_manager()));
 
     // Test that session can be wrapped in Arc (for thread safety)
     let session_clone = session.clone();
@@ -59,7 +59,7 @@ fn test_websocket_session_arc_compatibility() {
 #[test]
 fn test_websocket_session_debug_format() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     let debug_output = format!("{:?}", session);
     assert!(debug_output.contains("WebSocketSession"));
@@ -70,7 +70,7 @@ fn test_websocket_session_config_access() {
     let config =
         WebSocketConfig::default().with_heartbeat_interval(std::time::Duration::from_secs(45));
 
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // Test that config can be accessed
     let config_ref = session.config();
@@ -80,7 +80,7 @@ fn test_websocket_session_config_access() {
 #[test]
 fn test_websocket_session_subscription_manager() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // Test that subscription manager can be accessed
     let manager = session.subscription_manager();
@@ -90,7 +90,7 @@ fn test_websocket_session_subscription_manager() {
 #[tokio::test]
 async fn test_websocket_session_state() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // Initial state should be Disconnected
     let state = session.state().await;
@@ -102,7 +102,7 @@ async fn test_websocket_session_set_state() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // Set state to Connected
     session.set_state(ConnectionState::Connected).await;
@@ -113,7 +113,7 @@ async fn test_websocket_session_set_state() {
 #[tokio::test]
 async fn test_websocket_session_is_connected_false() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // Initial state is Disconnected, so is_connected should be false
     assert!(!session.is_connected().await);
@@ -124,7 +124,7 @@ async fn test_websocket_session_is_connected_true() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     session.set_state(ConnectionState::Connected).await;
     assert!(session.is_connected().await);
@@ -133,7 +133,7 @@ async fn test_websocket_session_is_connected_true() {
 #[tokio::test]
 async fn test_websocket_session_is_authenticated_false() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     assert!(!session.is_authenticated().await);
 }
@@ -143,7 +143,7 @@ async fn test_websocket_session_is_authenticated_true() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     session.set_state(ConnectionState::Authenticated).await;
     assert!(session.is_authenticated().await);
@@ -152,7 +152,7 @@ async fn test_websocket_session_is_authenticated_true() {
 #[tokio::test]
 async fn test_websocket_session_mark_authenticated() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     session.mark_authenticated().await;
     assert!(session.is_authenticated().await);
@@ -163,7 +163,7 @@ async fn test_websocket_session_mark_disconnected() {
     use deribit_websocket::model::ConnectionState;
 
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // First connect and authenticate
     session.set_state(ConnectionState::Authenticated).await;
@@ -178,7 +178,7 @@ async fn test_websocket_session_mark_disconnected() {
 #[tokio::test]
 async fn test_websocket_session_reactivate_subscriptions() {
     let config = WebSocketConfig::default();
-    let session = WebSocketSession::new(config, make_subscription_manager());
+    let session = WebSocketSession::new(Arc::new(config), make_subscription_manager());
 
     // This should not panic
     session.reactivate_subscriptions().await;


### PR DESCRIPTION
## Summary

Polish pass combining three low-priority tidy-up tickets into a single PR per explicit request: cut the duplicate `WebSocketConfig` clone in `DeribitWebSocketClient::new` (#57), tighten rustdoc quality in `message::builder`, `utils`, and `prelude` + enable `rustdoc::broken_intra_doc_links` and `rustdoc::missing_crate_level_docs` with a CI doc step (#56), and expand the existing CI TLS matrix to compile every `examples/*.rs` under every backend (#54).

## Changes

### Commit 1 — `#57 reduce WebSocketConfig clones to one`

- `src/session/ws_session.rs`: `WebSocketSession::new` first parameter changes from `WebSocketConfig` → `Arc<WebSocketConfig>`. Field assignment goes from `Arc::new(config)` → `config` (already an `Arc`).
- `src/client.rs`: `DeribitWebSocketClient::new` wraps the caller's `&WebSocketConfig` into an `Arc` once, then shares it with the inner `WebSocketSession` via `Arc::clone`. The duplicate struct clone (previously at line 48) is gone. The remaining `Arc::new(config.clone())` is the structurally unavoidable `&WebSocketConfig → Arc<WebSocketConfig>` boundary and is now documented as such.
- `tests/unit/session.rs`: 17 call sites to `WebSocketSession::new(config, ...)` updated to `WebSocketSession::new(Arc::new(config), ...)`. All tests remain green (431 unit/integration + 6 doctests).

Public API of `DeribitWebSocketClient::new` unchanged. Public API of `WebSocketSession::new` changes its first parameter type, but a grep of `src/`, `tests/`, `examples/`, and `benches/` found no external construction of `WebSocketSession` outside of the `DeribitWebSocketClient::new` call site and the 17 unit tests, so the blast radius is contained.

### Commit 2 — `#56 rustdoc quality audit: builder + utils + prelude, enable link lints`

- `src/message/builder.rs`: every public item now has substantive docs (not one-liners). `MessageBuilder` struct doc explains the stateless-vs-stateful split across its three sub-components; accessor methods explain why each is mutable or immutable; `parse_message` gains an `# Errors` section describing the `InvalidData` catch-all. `MessageType` variants describe each JSON-RPC frame kind and note that `Request` is round-trip-only (`parse_message` never returns it). `#[must_use]` added to three accessor returns per project rules.
- `src/utils/mod.rs`: module doc expanded from a 1-sentence blurb to a short description + runnable example, linking to the `prelude` re-export.
- `src/utils/logger.rs`: `setup_logger` now documents the process-global `tracing::set_global_default` semantics, the `Once` guard, and the fact that post-first-call changes to `DERIBIT_LOG_LEVEL` are ignored.
- `src/prelude.rs`: module doc expanded from 2 lines into a "what you get / what you do not get" checklist, with explicit pointers at `crate::model`, `crate::connection`, `crate::tls`, and `crate::error` for the long-tail types outside the prelude.
- `src/lib.rs`: added `#![warn(rustdoc::broken_intra_doc_links)]` and `#![warn(rustdoc::missing_crate_level_docs)]`.
- `src/config.rs`: fixed ~8 pre-existing broken intra-doc links surfaced by the new lint (`DeribitWebSocketClient` → `crate::client::DeribitWebSocketClient`, `WebSocketError` → `crate::error::WebSocketError`). Also resolved two `public documentation links to private item` warnings on `try_new` / `with_url` by demoting `[``Self::load_env``]` to plain inline code.
- `README.md`: regenerated via `cargo readme`.

### Commit 3 — `#54 #56 CI: --all-targets matrix for every TLS backend + rustdoc -D warnings job`

- `.github/workflows/build.yml`:
  - The existing 2×3 TLS matrix step changes from `cargo build` to `cargo build --all-targets`. `--all-targets` = lib + bins + tests + examples + benches, so every `examples/*.rs` is compiled under **every** TLS backend on every PR. This subsumes the literal `#54` ask and gives cross-backend example coverage for free.
  - New `rustdoc` job runs `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features integration-tests`. Enforces the two new lints as hard CI failures. `--features integration-tests` is used instead of `--all-features` because the latter trips the TLS mutex (same reasoning as `make lint`, established in PR #70).

## Acceptance criteria

| # | Criterion | Commit | Status |
|---|-----------|--------|--------|
| #54-1 | CI compiles examples under each TLS backend | 3 | ✅ verified locally |
| #54-2 | Example regression fails a matrix cell | 3 | ✅ by construction |
| #56-1 | `cargo doc -D warnings` green in CI | 2 + 3 | ✅ verified locally |
| #56-2 | `#![warn(rustdoc::broken_intra_doc_links)]` + `#![warn(rustdoc::missing_crate_level_docs)]` active | 2 | ✅ in `src/lib.rs` |
| #56-3 | Every public item in builder / utils / prelude has substantive docs | 2 | ✅ audited |
| #57-1 | `WebSocketSession::new` accepts `Arc<WebSocketConfig>` | 1 | ✅ |
| #57-2 | Exactly one `config.clone()` remaining in `src/` (narrative) | 1 | ✅ `src/client.rs:92`, documented as unavoidable |
| #57-3 | No behavior change | 1 | ✅ 431 tests + 6 doctests green |

Note on the `rg 'config\.clone()' src/` → 0 hits wording in #57: per our pre-plan alignment we went with the issue body's narrative ("Net: eliminate the `config.clone()` at line 48", singular) rather than the acceptance line's literal 0-hit target, which would have required a breaking change to `DeribitWebSocketClient::new`'s public signature.

## Testing

- [x] Unit tests — existing 17 `WebSocketSession` tests updated and green.
- [x] Integration tests — mock-server suite (6 tests) green.
- [ ] Benchmark tests — N/A.
- [x] Manual verification:
  - `cargo test` — 431 tests + 6 doctests pass.
  - `cargo build --all-targets --no-default-features --features $TLS` — green for all three backends.
  - `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features integration-tests` — green.
  - `make lint` / `make lint-strict` / `cargo fmt --check` / `cargo build --release` — all clean.
  - Mutex regression: `cargo build --no-default-features --features rustls-aws-lc,rustls-ring` still fails with one `compile_error!` diagnostic.

## Checklist

- [x] All public items have `///` documentation.
- [x] No warnings from `cargo clippy --all-targets --features integration-tests -- -D warnings`.
- [x] `cargo fmt --all --check` passes.
- [x] No `.unwrap()` / `.expect()` / panics added in library code.
- [x] WebSocket connection lifecycle unchanged (one-line refactor).
- [x] Minimal dependencies — zero new crates.

Closes #54
Closes #56
Closes #57
