### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-19
+
+### Migration note
+
+The default TLS backend changed from `native-tls` to `rustls-aws-lc`. Downstream crates that relied on the previous default must now either accept the new default or opt back in explicitly:
+
+```toml
+deribit-websocket = { version = "0.3.0", default-features = false, features = ["native-tls"] }
+```
+
+Every binary that opens a WebSocket connection must also call `deribit_websocket::install_default_crypto_provider()` once at startup, before the first `connect()`. This is a no-op under `native-tls` and selects the right rustls provider under the two rustls backends. See the "TLS backend selection" section of the README.
+
+### Added
+- TLS backend feature flags `rustls-aws-lc` (new default), `rustls-ring`, and `native-tls`, mutually exclusive, enforced at compile time by a `compile_error!` mutex that rejects multi-backend builds (#55, PR #70).
+- `install_default_crypto_provider()` helper that idempotently installs the correct rustls provider for the active feature and is a no-op under `native-tls` (#55).
+- `WebSocketConfig::try_new()` fallible constructor that propagates `DERIBIT_WS_URL` parse errors instead of panicking (#48).
+- Mock-server integration test suite covering connect, authenticate, subscribe/unsubscribe lifecycles and reconnect scenarios end-to-end (#53).
+- `WebSocketError::ApiError` now carries the originating request method, params, and a size-bounded redacted raw response payload for post-mortem debugging (#52).
+- Extended rustdoc on `message::builder`, `utils`, `utils::logger`, and the `prelude` module header: every public item has substantive docs with `# Errors` sections where applicable; prelude has a "what you get / what you do not get" checklist (#56).
+- `#![warn(rustdoc::broken_intra_doc_links)]` and `#![warn(rustdoc::missing_crate_level_docs)]` in `lib.rs`, enforced in CI via `RUSTDOCFLAGS="-D warnings" cargo doc` (#56).
+- CI matrix builds every example and every test target under each of the three TLS backends via `cargo build --all-targets --no-default-features --features <backend>` (#54).
+- CI `mutex-check` negative job that confirms the `compile_error!` mutex still rejects builds activating two TLS backends simultaneously (#55).
+- `#[must_use]` annotations on pure functions and builder returns across the message-builder surface per project guidelines (#56).
+- README sections documenting the TLS backend selection, the `install_default_crypto_provider()` helper, connection/request timeouts, and backpressure strategy.
+
+### Changed
+- **Default TLS backend is now `rustls-aws-lc`** — was `native-tls`. See the migration note above (#55, PR #70).
+- `WebSocketSession::new` now accepts `impl Into<Arc<WebSocketConfig>>` so both owned `WebSocketConfig` (backward compatible) and `Arc<WebSocketConfig>` (zero-copy) callers compile. `DeribitWebSocketClient::new` uses the zero-copy path internally, eliminating the duplicate struct clone that used to happen on every client construction (#57).
+- `WebSocketConfig::default()` no longer panics if `DERIBIT_WS_URL` is malformed — it falls back to a hard-coded production-URL safe default, keeping the fallible-but-panicking behaviour inside `try_new` only (#48).
+- `DeribitWebSocketClient::connect()` now bounds the WebSocket handshake by the configured `connection_timeout`; a stalled listener during the TLS/HTTP upgrade surfaces `WebSocketError::Timeout` instead of hanging (#50).
+- `subscribe()` / `unsubscribe()` now reconcile the active-subscription set against the channel list echoed by the server rather than the caller's input list; rejected channels no longer poison local state (#62, #65).
+- Notification channel backpressure is explicitly documented as Strategy A (await-send) — the dispatcher blocks on full, stops polling the socket, and emits a `tracing::warn!` per full-channel event; no frames are dropped unless the notification receiver has been closed (#51).
+- `send_request` borrows its request on the hot path instead of cloning it; one allocation removed per outbound request (#52).
+
+### Fixed
+- Serde errors thrown while constructing JSON-RPC payloads now propagate as `WebSocketError::Serialization` with context instead of being stringified via `.to_string()` (#46).
+- MMP config builder rejects non-finite floats (`NaN`, `±∞`) up front with a clear validation error rather than sending them over the wire (#46).
+- TLS provider installation is idempotent and returns a typed `CryptoProviderError::AlreadyInstalled` rather than panicking when called a second time, so libraries that wire logging and TLS from multiple entry points no longer race (#55).
+- Three examples (`new_channels_subscription`, `mass_quote_advanced`, `mass_quote_options`) degraded gracefully on accounts without authenticated raw-stream access or without Market Maker Protection activated; previously they crashed on the first `11050` or `13778` error.
+
+### Documentation
+- Expanded crate-level `lib.rs` header with a backpressure architecture section.
+- Audited public items in `message::builder`, `utils`, and `prelude` to remove signature-restating one-liners and add examples + `# Errors` sections where meaningful (#56).
+
+### CI
+- New `rustdoc (-D warnings)` job enforcing the two new rustdoc lints.
+- Existing TLS backend matrix upgraded from `cargo build` (lib only) to `cargo build --all-targets` so every example and test target is compiled under every backend on every PR.
+- Negative `mutex-check` job verifies the `compile_error!` barrier in `src/tls.rs`.
+
 ## [0.2.1] - 2026-03-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Every binary that opens a WebSocket connection must also call `deribit_websocket
 - Comprehensive error handling
 - Example implementations for common use cases
 
+[0.3.0]: https://github.com/joaquinbejar/deribit-websocket/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/joaquinbejar/deribit-websocket/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/joaquinbejar/deribit-websocket/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/joaquinbejar/deribit-websocket/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deribit-websocket"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "WebSocket client for Deribit trading platform real-time data"

--- a/examples/mass_quote_advanced.rs
+++ b/examples/mass_quote_advanced.rs
@@ -128,10 +128,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     // MMP configuration requires the feature to be activated on the
-    // account by Deribit staff. A 11050 `bad_request` with payload
-    // `"MMP disabled"` is the expected response on accounts without
-    // activation — log it and carry on so the rest of the demo still
-    // exercises its API surface without crashing.
+    // account by Deribit staff. A `11050 bad_request` with payload
+    // `"MMP disabled"` is the specific response on accounts without
+    // activation — only that case is treated as non-fatal so the demo
+    // keeps exercising its API surface. Any other error (auth,
+    // serialization, connectivity, validation, ...) still propagates
+    // and fails the example fast.
     for (group_name, qty_limit, delta_limit, interval, frozen_time) in &mmp_groups {
         let config = MmpGroupConfig::new(
             group_name.to_string(),
@@ -143,11 +145,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         match client.set_mmp_config(config).await {
             Ok(()) => tracing::info!("✅ MMP group '{}' configured", group_name),
-            Err(e) => tracing::warn!(
-                "⚠️  MMP group '{}' config failed: {} — expected if MMP is not activated",
+            Err(WebSocketError::ApiError {
+                code: 11050,
+                message,
+                ..
+            }) => tracing::warn!(
+                "⚠️  MMP group '{}' skipped: {} (code 11050 — MMP not activated on this account)",
                 group_name,
-                e
+                message
             ),
+            Err(e) => return Err(e.into()),
         }
     }
 

--- a/examples/mass_quote_advanced.rs
+++ b/examples/mass_quote_advanced.rs
@@ -127,6 +127,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ("btc_scalping", 2.0, 1.0, 200, 1000),     // Scalping, very tight
     ];
 
+    // MMP configuration requires the feature to be activated on the
+    // account by Deribit staff. A 11050 `bad_request` with payload
+    // `"MMP disabled"` is the expected response on accounts without
+    // activation — log it and carry on so the rest of the demo still
+    // exercises its API surface without crashing.
     for (group_name, qty_limit, delta_limit, interval, frozen_time) in &mmp_groups {
         let config = MmpGroupConfig::new(
             group_name.to_string(),
@@ -136,8 +141,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             *frozen_time,
         )?;
 
-        client.set_mmp_config(config).await?;
-        tracing::info!("✅ MMP group '{}' configured", group_name);
+        match client.set_mmp_config(config).await {
+            Ok(()) => tracing::info!("✅ MMP group '{}' configured", group_name),
+            Err(e) => tracing::warn!(
+                "⚠️  MMP group '{}' config failed: {} — expected if MMP is not activated",
+                group_name,
+                e
+            ),
+        }
     }
 
     // Step 2: Create layered quotes across multiple groups

--- a/examples/mass_quote_options.rs
+++ b/examples/mass_quote_options.rs
@@ -113,7 +113,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     tracing::info!("📡 Subscribed to options mark prices and trades");
 
-    // Step 1: Create MMP group for options trading
+    // Step 1: Create MMP group for options trading.
+    //
+    // MMP configuration requires the feature to be activated on the
+    // account by Deribit staff. A 11050 `bad_request` with payload
+    // `"MMP disabled"` is the expected response on accounts without
+    // activation — log it and carry on so the rest of the demo still
+    // exercises its API surface without crashing.
     tracing::info!("📋 Setting up options MMP group...");
 
     let options_mmp_config = MmpGroupConfig::new(
@@ -124,8 +130,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         10000, // 10 second freeze after trigger
     )?;
 
-    client.set_mmp_config(options_mmp_config).await?;
-    tracing::info!("✅ Options MMP group 'btc_options_mm' configured");
+    match client.set_mmp_config(options_mmp_config).await {
+        Ok(()) => tracing::info!("✅ Options MMP group 'btc_options_mm' configured"),
+        Err(e) => tracing::warn!(
+            "⚠️  Options MMP group config failed: {} — expected if MMP is not activated",
+            e
+        ),
+    }
 
     // Step 2: Create options quotes for calls and puts
     tracing::info!("📊 Creating options mass quotes...");

--- a/examples/mass_quote_options.rs
+++ b/examples/mass_quote_options.rs
@@ -116,10 +116,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Create MMP group for options trading.
     //
     // MMP configuration requires the feature to be activated on the
-    // account by Deribit staff. A 11050 `bad_request` with payload
-    // `"MMP disabled"` is the expected response on accounts without
-    // activation — log it and carry on so the rest of the demo still
-    // exercises its API surface without crashing.
+    // account by Deribit staff. A `11050 bad_request` with payload
+    // `"MMP disabled"` is the specific response on accounts without
+    // activation — only that case is treated as non-fatal so the demo
+    // keeps exercising its API surface. Any other error still
+    // propagates so auth, serialization, or connectivity failures
+    // surface immediately.
     tracing::info!("📋 Setting up options MMP group...");
 
     let options_mmp_config = MmpGroupConfig::new(
@@ -132,10 +134,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match client.set_mmp_config(options_mmp_config).await {
         Ok(()) => tracing::info!("✅ Options MMP group 'btc_options_mm' configured"),
-        Err(e) => tracing::warn!(
-            "⚠️  Options MMP group config failed: {} — expected if MMP is not activated",
-            e
+        Err(WebSocketError::ApiError {
+            code: 11050,
+            message,
+            ..
+        }) => tracing::warn!(
+            "⚠️  Options MMP group skipped: {} (code 11050 — MMP not activated on this account)",
+            message
         ),
+        Err(e) => return Err(e.into()),
     }
 
     // Step 2: Create options quotes for calls and puts

--- a/examples/new_channels_subscription.rs
+++ b/examples/new_channels_subscription.rs
@@ -56,12 +56,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Trades by Kind - trades for all futures or options.
     //
-    // NOTE: `raw` interval requires authentication (server code 13778:
-    // `raw_subscriptions_not_available_for_unauthorized`) and, because
-    // subscribe is all-or-nothing, including a `raw` channel in an
-    // unauthenticated batch causes every channel in the batch to be
-    // rejected. Public callers must use a bucketed interval such as
-    // `100ms` or `agg2`.
+    // NOTE: the `raw` interval requires authentication — unauthenticated
+    // callers get server code 13778
+    // (`raw_subscriptions_not_available_for_unauthorized`) and the
+    // `raw` channel is dropped from the confirmed subscription list.
+    // This example runs unauthenticated, so it uses a bucketed
+    // interval such as `100ms` or `agg2`. Authenticated callers may
+    // pass `"raw"` here instead.
     let trades_by_kind = SubscriptionChannel::TradesByKind {
         kind: "future".to_string(),
         currency: "BTC".to_string(),

--- a/examples/new_channels_subscription.rs
+++ b/examples/new_channels_subscription.rs
@@ -54,11 +54,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let incremental_ticker = SubscriptionChannel::IncrementalTicker("BTC-PERPETUAL".to_string());
     tracing::info!("Incremental ticker channel: {}", incremental_ticker);
 
-    // 3. Trades by Kind - trades for all futures or options
+    // 3. Trades by Kind - trades for all futures or options.
+    //
+    // NOTE: `raw` interval requires authentication (server code 13778:
+    // `raw_subscriptions_not_available_for_unauthorized`) and, because
+    // subscribe is all-or-nothing, including a `raw` channel in an
+    // unauthenticated batch causes every channel in the batch to be
+    // rejected. Public callers must use a bucketed interval such as
+    // `100ms` or `agg2`.
     let trades_by_kind = SubscriptionChannel::TradesByKind {
         kind: "future".to_string(),
         currency: "BTC".to_string(),
-        interval: "raw".to_string(),
+        interval: "100ms".to_string(),
     };
     tracing::info!("Trades by kind channel: {}", trades_by_kind);
 


### PR DESCRIPTION
## Summary

Release cut of **v0.3.0**. Aggregates every PR merged on `main` since `v0.2.1` (2026-03-07). Three commits:

1. `examples: graceful degradation when account features are inactive` — fixes three examples (`new_channels_subscription`, `mass_quote_advanced`, `mass_quote_options`) that crashed on accounts without raw-stream auth or MMP activation. No library changes.
2. `chore: bump version to 0.3.0` — `Cargo.toml` only.
3. `docs: add 0.3.0 entry to CHANGELOG` — Keep-a-Changelog block covering the release surface.

## Migration note

**Default TLS backend changed from `native-tls` to `rustls-aws-lc`.** Downstream crates that relied on the previous default must now either accept the new default or opt back in explicitly:

```toml
deribit-websocket = { version = "0.3.0", default-features = false, features = ["native-tls"] }
```

Every binary that opens a WebSocket connection must also call `deribit_websocket::install_default_crypto_provider()` once at startup, before the first `connect()`. This is a no-op under `native-tls` and selects the right rustls provider under the two rustls backends.

## Full CHANGELOG block

See `CHANGELOG.md` on the branch for the full, grouped entry. Highlights:

- **Added** — TLS feature flags + `compile_error!` mutex (#55), `install_default_crypto_provider()` helper, `WebSocketConfig::try_new()` (#48), mock-server integration suite (#53), enriched `WebSocketError::ApiError` (#52), rustdoc link lints + CI job (#56), `--all-targets` CI matrix (#54), `#[must_use]` audit (#56), README TLS/timeouts/backpressure sections.
- **Changed** — Default TLS backend (#55, **breaking for downstream that relied on `native-tls`**), `WebSocketSession::new` now `impl Into<Arc<WebSocketConfig>>` + duplicate clone eliminated (#57), `WebSocketConfig::default()` no longer panics (#48), bounded connect handshake (#50), server-echo subscribe/unsubscribe reconciliation (#62, #65), documented Strategy A backpressure (#51), borrowed hot-path request (#52).
- **Fixed** — serde errors propagate as `WebSocketError::Serialization` (#46), MMP float validation (#46), idempotent TLS provider install (#55), graceful example degradation on inactive accounts.
- **Documentation / CI** — rustdoc audit (#56), new `rustdoc (-D warnings)` job, every example compiled under every TLS backend.

## Example verification

Every example in `examples/` was run against `wss://test.deribit.com/ws/api/v2` with real testnet credentials. Summary:

| Example | Result | Notes |
|---|---|---|
| `basic_client` | ✅ pass | 8 book messages |
| `advanced_subscriptions` | ✅ pass | 23 chart messages across BTC/ETH |
| `session_management` | ✅ pass | heartbeat round-trip |
| `mark_price_subscription` | ✅ pass | subscribe/unsubscribe, 0 options ticks during window |
| `trades_subscription` | ✅ pass | subscribe/unsubscribe, 0 trades during window |
| `quote_subscription` | ✅ pass | 69 quote updates |
| `perpetual_subscription` | ✅ pass | |
| `price_index_subscription` | ✅ pass | 49 index updates |
| `expiration_price_subscription` | ✅ pass | 8 updates |
| `callback_example` | ✅ pass | 24 success + 4 simulated-error callbacks |
| `new_channels_subscription` | 🔧 adapted | `trades.future.BTC.raw` needs auth; swapped to `100ms` |
| `callback_example` | ✅ pass | |
| `account_operations` | ✅ pass | balances + positions retrieved |
| `portfolio_subscription` | ✅ pass | 17 portfolio updates |
| `user_orders_subscription` | ✅ pass | 0 updates (no activity) |
| `user_trades_subscription` | ✅ pass | 0 trades (no activity) |
| `unsubscribe_all` | ✅ pass | full public + private round-trip |
| `position_management` | ✅ pass | doc demo, no mutating calls |
| `cancel_on_disconnect` | ✅ pass | enable + verify + disable + verify |
| `mass_quote_basic` | ✅ pass | graceful on MMP-disabled account |
| `mass_quote_advanced` | 🔧 adapted | `?` on `set_mmp_config` inside loop → match + warn + continue |
| `mass_quote_options` | 🔧 adapted | same pattern, single call → match + warn + continue |
| `trading_operations` | ✅ pass | buy + edit + cancel + sell + 3x cancel-all |

Three adaptations were example-level (misleading error handling / channel names) and required no library changes. No library bugs were surfaced during verification, so no new issues were filed.

## Testing

- [x] Every `examples/*.rs` runs against testnet and exits 0.
- [x] `cargo test` — 104 + 431 + 8 + 6 = 549 tests, all green.
- [x] `cargo build --release` clean.
- [x] `cargo build --all-targets --no-default-features --features <rustls-aws-lc|rustls-ring|native-tls>` all green.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features integration-tests` clean.
- [x] `make lint`, `make lint-strict`, `cargo fmt --check` all clean.
- [x] Mutex regression guard: `cargo build --no-default-features --features rustls-aws-lc,rustls-ring` still fails with the `compile_error!` diagnostic.

## Checklist

- [x] `Cargo.toml` version bumped.
- [x] `CHANGELOG.md` updated with a dated 0.3.0 entry grouped per Keep a Changelog.
- [x] Migration note called out at the top of the 0.3.0 section for the TLS default change.
- [x] No breaking changes inside a minor version from a caller's code path except the intentional TLS default swap (already covered by issue #55 / PR #70 acceptance).
- [x] Every example compiles and runs against testnet.
- [ ] Git tag `v0.3.0` — **deferred to post-merge**, not created in this PR.
- [ ] Publish to crates.io — out of scope for this PR.
